### PR TITLE
Remove paw icons

### DIFF
--- a/src/components/CustomerLove.tsx
+++ b/src/components/CustomerLove.tsx
@@ -43,7 +43,7 @@ const CustomerLove = () => {
     {
       name: "Jennifer W.",
       rating: 5,
-      text: "Game changer for our family! Professional service and spotless results every time. 🐾",
+      text: "Game changer for our family! Professional service and spotless results every time.",
       date: "2 days ago"
     },
     {

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -81,7 +81,7 @@ const Hero = () => {
 
               {/* Floating elements */}
               <div className="absolute -top-8 -left-8 w-16 h-16 bg-[#9DE5FF] rounded-full flex items-center justify-center text-2xl animate-bounce">
-                🐾
+                ✨
               </div>
               <div className="absolute -bottom-4 -right-8 w-12 h-12 bg-[#A8F483] rounded-full flex items-center justify-center text-xl animate-pulse">
                 ✨

--- a/src/components/InteractivePricing.tsx
+++ b/src/components/InteractivePricing.tsx
@@ -191,16 +191,14 @@ const InteractivePricing = () => {
               {[...Array(20)].map((_, i) => (
                 <div
                   key={i}
-                  className="absolute w-4 h-4 animate-ping"
+                  className="absolute w-4 h-4 bg-[#4CAF50] rounded-full animate-ping"
                   style={{
                     left: `${Math.random() * 200 - 100}px`,
                     top: `${Math.random() * 200 - 100}px`,
                     animationDelay: `${Math.random() * 2}s`,
                     animationDuration: '1s'
                   }}
-                >
-                  🐾
-                </div>
+                />
               ))}
             </div>
           </div>

--- a/src/components/PawCursor.tsx
+++ b/src/components/PawCursor.tsx
@@ -43,7 +43,7 @@ const PawCursor = () => {
       {trails.map((trail, index) => (
         <div
           key={trail.id}
-          className="absolute w-4 h-4 text-[#4CAF50] animate-ping"
+          className="absolute w-4 h-4 bg-[#4CAF50] rounded-full animate-ping"
           style={{
             left: trail.x - 8,
             top: trail.y - 8,
@@ -51,9 +51,7 @@ const PawCursor = () => {
             animationDelay: `${index * 100}ms`,
             animationDuration: '1s'
           }}
-        >
-          🐾
-        </div>
+        />
       ))}
     </div>
   );

--- a/src/components/ServiceCards.tsx
+++ b/src/components/ServiceCards.tsx
@@ -153,9 +153,9 @@ const ServiceCards = () => {
                   {service.popular ? 'Choose Deluxe' : 'Select Plan'}
                 </button>
 
-                {/* Paw print decoration */}
+                {/* Decorative icon */}
                 <div className="absolute -bottom-2 -right-2 text-2xl opacity-20">
-                  🐾
+                  ✨
                 </div>
               </div>
             );


### PR DESCRIPTION
## Summary
- replace cursor paw emojis with small circles
- swap remaining 🐾 graphics with sparkles and stars
- remove paw emoji from testimonials

## Testing
- `npm run lint` *(fails: unknown env config, missing packages, ESLint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6877e71d029c832384c66474fb9c486c