### PR TITLE
Fix pricing logic in onboarding wizard

### DIFF
--- a/src/components/ComicStrip.tsx
+++ b/src/components/ComicStrip.tsx
@@ -3,7 +3,6 @@ import { ChevronLeft, ChevronRight } from 'lucide-react';
 
 const ComicStrip = () => {
   const [currentFrame, setCurrentFrame] = useState(0);
-  const [isAnimating, setIsAnimating] = useState(false);
 
   const frames = [
     {
@@ -53,8 +52,6 @@ const ComicStrip = () => {
         
         if (targetFrame !== currentFrame && targetFrame < frames.length) {
           setCurrentFrame(targetFrame);
-          setIsAnimating(true);
-          setTimeout(() => setIsAnimating(false), 500);
         }
       }
     };
@@ -66,23 +63,17 @@ const ComicStrip = () => {
   const nextFrame = () => {
     if (currentFrame < frames.length - 1) {
       setCurrentFrame(currentFrame + 1);
-      setIsAnimating(true);
-      setTimeout(() => setIsAnimating(false), 500);
     }
   };
 
   const prevFrame = () => {
     if (currentFrame > 0) {
       setCurrentFrame(currentFrame - 1);
-      setIsAnimating(true);
-      setTimeout(() => setIsAnimating(false), 500);
     }
   };
 
   const goToFrame = (index: number) => {
     setCurrentFrame(index);
-    setIsAnimating(true);
-    setTimeout(() => setIsAnimating(false), 500);
   };
 
   return (

--- a/src/components/CustomerLove.tsx
+++ b/src/components/CustomerLove.tsx
@@ -96,7 +96,6 @@ const CustomerLove = () => {
   };
 
   const currentTest = testimonials[currentTestimonial];
-  const currentRev = reviews[currentReview];
 
   return (
     <section id="customer-love" className="py-20 bg-[#FFF8F2]">

--- a/src/components/InteractivePricing.tsx
+++ b/src/components/InteractivePricing.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { DollarSign, TrendingUp, Star, Zap } from 'lucide-react';
+import { DollarSign } from 'lucide-react';
 
 const InteractivePricing = () => {
   const [dogCount, setDogCount] = useState(1);

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { ChevronRight, ChevronLeft, MapPin, Users, Calendar, CreditCard, Check } from 'lucide-react';
+import { ChevronRight, ChevronLeft, MapPin, Users, Calendar, Check } from 'lucide-react';
 
 const OnboardingWizard = () => {
   const [currentStep, setCurrentStep] = useState(1);
@@ -39,6 +39,7 @@ const OnboardingWizard = () => {
       id: 'weekly-basic',
       name: 'Weekly Basic',
       price: formData.dogCount <= 3 ? 35 : formData.dogCount <= 6 ? 55 : 75,
+      period: 'week',
       description: `Perfect for ${formData.dogCount} dog${formData.dogCount > 1 ? 's' : ''}`,
       features: ['Weekly service', 'Basic cleanup', 'Eco-friendly disposal']
     },
@@ -46,6 +47,7 @@ const OnboardingWizard = () => {
       id: 'deluxe',
       name: 'Bi-Weekly Deluxe',
       price: 89,
+      period: 'bi-weekly',
       description: 'Unlimited dogs, premium service',
       features: ['Bi-weekly service', 'Unlimited dogs', 'Deep sanitization', 'Free dispenser'],
       popular: true
@@ -68,7 +70,7 @@ const OnboardingWizard = () => {
     }
   };
 
-  const updateFormData = (field: string, value: any) => {
+  const updateFormData = (field: string, value: string | number) => {
     setFormData(prev => ({ ...prev, [field]: value }));
   };
 
@@ -233,9 +235,10 @@ const OnboardingWizard = () => {
                       <h4 className="font-bold text-lg text-gray-800 mb-2">
                         {plan.name}
                       </h4>
-                      <div className="text-2xl font-black text-gray-800 mb-2">
-                        ${plan.price}
-                      </div>
+                    <div className="text-2xl font-black text-gray-800 mb-2">
+                      ${plan.price}
+                      <span className="text-sm font-normal text-gray-600">/{plan.period}</span>
+                    </div>
                       <p className="text-sm text-gray-600 mb-4">
                         {plan.description}
                       </p>
@@ -319,8 +322,17 @@ const OnboardingWizard = () => {
                     <span>{plans.find(p => p.id === formData.plan)?.name}</span>
                   </div>
                   <div className="flex justify-between font-bold text-gray-800">
-                    <span>Total:</span>
-                    <span>${plans.find(p => p.id === formData.plan)?.price}</span>
+                    <span>Total (monthly):</span>
+                    <span>
+                      {
+                        (() => {
+                          const plan = plans.find(p => p.id === formData.plan);
+                          if (!plan) return '$0';
+                          const multiplier = plan.period === 'week' ? 4 : 2;
+                          return `$${plan.price * multiplier}`;
+                        })()
+                      }
+                    </span>
                   </div>
                 </div>
               </div>

--- a/src/components/ReferralRewards.tsx
+++ b/src/components/ReferralRewards.tsx
@@ -2,8 +2,8 @@ import React, { useState } from 'react';
 import { Gift, Users, Share2, Trophy } from 'lucide-react';
 
 const ReferralRewards = () => {
-  const [referralCode, setReferralCode] = useState('SCOOP-FRIEND-2024');
-  const [referralCount, setReferralCount] = useState(0);
+  const [referralCode] = useState('SCOOP-FRIEND-2024');
+  const [referralCount] = useState(0);
   const [showBadge, setShowBadge] = useState(false);
 
   const rewards = [


### PR DESCRIPTION
## Summary
- clarify periods for pricing options
- display weekly/bi-weekly text when selecting plans
- show correct monthly total
- clean up unused variables and imports

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877e801a9c08323b38c17a18e268117