### PR TITLE
Add about section with navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,8 @@ import Footer from './components/Footer';
 import UrgencyRibbon from './components/UrgencyRibbon';
 import ExitIntentPopup from './components/ExitIntentPopup';
 import PawCursor from './components/PawCursor';
+import NavTabs from './components/NavTabs';
+import About from './components/About';
 
 function App() {
   const [showExitPopup, setShowExitPopup] = useState(false);
@@ -44,7 +46,9 @@ function App() {
     <div className="min-h-screen bg-[#FFF8F2] relative overflow-x-hidden">
       {showPawCursor && <PawCursor />}
       <UrgencyRibbon />
+      <NavTabs />
       <Hero />
+      <About />
       <ComicStrip />
       <HowItWorks />
       <InteractivePricing />

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+const About = () => (
+  <section id="about" className="py-20 bg-[#FFF8F2]">
+    <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 grid md:grid-cols-2 gap-10 items-center">
+      <div className="h-64 md:h-80 bg-gray-200 rounded-3xl flex items-center justify-center shadow-inner">
+        {/* Replace the emoji with your photo */}
+        <span className="text-6xl">📸</span>
+      </div>
+      <div className="space-y-6">
+        <h2 className="text-4xl font-black text-gray-800">About Me</h2>
+        <p className="text-gray-700 text-lg leading-relaxed">
+          I'm an ambitious entrepreneur and software engineering student at Iowa State University with a deep love for dogs. My mission is to build innovative businesses that help pay for my tuition while creating software that drives America forward.
+        </p>
+        <p className="text-gray-700 text-lg leading-relaxed">
+          From pet care services to cutting-edge apps, I'm always exploring new ideas that bring value to people—and their pups. Your support fuels my education and my dream of launching tech ventures that make a real difference.
+        </p>
+        <p className="text-gray-700 text-lg leading-relaxed">
+          If my story inspires you, consider partnering with me or contributing to my projects. Together, we can build a brighter future for our communities and our four-legged friends.
+        </p>
+      </div>
+    </div>
+  </section>
+);
+
+export default About;

--- a/src/components/NavTabs.tsx
+++ b/src/components/NavTabs.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+const NavTabs = () => {
+  const tabs = [
+    { label: 'Home', href: '#hero' },
+    { label: 'About', href: '#about' },
+    { label: 'Plans', href: '#service-cards' },
+    { label: 'FAQ', href: '#faq' },
+  ];
+
+  return (
+    <nav className="sticky top-10 z-40 bg-white/90 backdrop-blur border-b border-gray-200">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <ul className="flex justify-center gap-6 py-3">
+          {tabs.map((tab) => (
+            <li key={tab.href}>
+              <a href={tab.href} className="text-gray-700 font-semibold hover:text-[#4CAF50]">
+                {tab.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </nav>
+  );
+};
+
+export default NavTabs;


### PR DESCRIPTION
## Summary
- add a sticky navigation bar with anchors to each section
- create an About section describing the entrepreneur behind the site
- integrate new components into the app

## Testing
- `npm run lint` *(fails: no-unused-vars and other issues)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6877e903584c8323b1020a9f6a0382c2