### PR TITLE
Add top logo banner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import ExitIntentPopup from './components/ExitIntentPopup';
 import PawCursor from './components/PawCursor';
 import NavTabs from './components/NavTabs';
 import About from './components/About';
+import LogoBanner from './components/LogoBanner';
 
 function App() {
   const [showExitPopup, setShowExitPopup] = useState(false);
@@ -48,6 +49,7 @@ function App() {
     <div className="min-h-screen bg-[#FFF8F2] relative overflow-x-hidden">
       {showPawCursor && <PawCursor />}
       <UrgencyRibbon />
+      <LogoBanner />
       <NavTabs />
       <Hero />
       <About />

--- a/src/components/LogoBanner.tsx
+++ b/src/components/LogoBanner.tsx
@@ -1,0 +1,32 @@
+import React, { useState, useEffect } from 'react';
+
+const LogoBanner = () => {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setVisible(window.scrollY <= 10);
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed top-10 left-0 right-0 z-40">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between bg-white rounded-full shadow-lg px-4 py-2">
+          <div className="flex items-center gap-2">
+            <span className="text-3xl">🐶</span>
+            <span className="font-black text-lg text-gray-800">Captain Scoop</span>
+          </div>
+          <div className="hidden sm:block text-3xl">🎈</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LogoBanner;

--- a/src/components/NavTabs.tsx
+++ b/src/components/NavTabs.tsx
@@ -9,7 +9,7 @@ const NavTabs = () => {
   ];
 
   return (
-    <nav className="sticky top-10 z-40 bg-white/90 backdrop-blur border-b border-gray-200">
+    <nav className="sticky top-24 z-40 bg-white/90 backdrop-blur border-b border-gray-200">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <ul className="flex justify-center gap-6 py-3">
           {tabs.map((tab) => (


### PR DESCRIPTION
## Summary
- create a `LogoBanner` component that appears when scrolled to the top
- show this banner under the urgency ribbon
- move navigation tabs lower to avoid overlap

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687814bb96e483238036f29ebf905d43