### PR TITLE
Implement flat-fee twice-weekly plan

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Captain Scoop - Dog Waste Removal Service | Never Step in It Again</title>
-    <meta name="description" content="Professional dog waste removal service. Bi-weekly deluxe plans, unlimited dogs, pristine yards. Book online in 60 seconds!" />
+    <meta name="description" content="Professional dog waste removal service. Twice-weekly deluxe plans, unlimited dogs, pristine yards. Book online in 60 seconds!" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@400;700;800;900&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/src/components/ComicStrip.tsx
+++ b/src/components/ComicStrip.tsx
@@ -37,7 +37,7 @@ const ComicStrip = () => {
       id: 5,
       image: "🥤",
       title: "The Reward",
-      caption: "Time to relax with Bi-Weekly Deluxe!",
+      caption: "Time to relax with Twice-Weekly Deluxe!",
       description: "Owner enjoys lemonade in clean yard"
     }
   ];
@@ -132,8 +132,8 @@ const ComicStrip = () => {
                         
                         {index === frames.length - 1 && (
                           <button className="group relative px-8 py-4 bg-[#4CAF50] hover:bg-[#45a049] text-white font-bold text-lg rounded-full transition-all duration-300 transform hover:scale-105 hover:shadow-xl">
-                            <span className="relative z-10">Book Bi-Weekly Deluxe</span>
-                            <div className="absolute inset-0 bg-white/20 rounded-full scale-0 group-hover:scale-100 transition-transform duration-300"></div>
+                            <span className="relative z-10">Book Twice-Weekly Deluxe</span>
+                          <div className="absolute inset-0 bg-white/20 rounded-full scale-0 group-hover:scale-100 transition-transform duration-300"></div>
                           </button>
                         )}
                       </div>

--- a/src/components/CustomerLove.tsx
+++ b/src/components/CustomerLove.tsx
@@ -12,7 +12,7 @@ const CustomerLove = () => {
       name: "Sarah Johnson",
       location: "Denver, CO",
       dogs: 3,
-      plan: "Bi-Weekly Deluxe",
+      plan: "Twice-Weekly Deluxe",
       video: "🎥",
       quote: "Captain Scoop saved our sanity! With three golden retrievers, our yard was... well, let's just say it wasn't pristine. Now it's perfect!",
       rating: 5
@@ -32,7 +32,7 @@ const CustomerLove = () => {
       name: "Emma Rodriguez",
       location: "Phoenix, AZ",
       dogs: 5,
-      plan: "Bi-Weekly Deluxe",
+      plan: "Twice-Weekly Deluxe",
       video: "🎥",
       quote: "Five dogs = A LOT of cleanup. The Deluxe plan is worth every penny. Our yard has never looked better!",
       rating: 5
@@ -61,7 +61,7 @@ const CustomerLove = () => {
     {
       name: "David L.",
       rating: 5,
-      text: "Bi-Weekly Deluxe is perfect for our pack of 4. Consistent, professional service. 🎯",
+      text: "Twice-Weekly Deluxe is perfect for our pack of 4. Consistent, professional service. 🎯",
       date: "3 weeks ago"
     }
   ];

--- a/src/components/DeluxeSpotlight.tsx
+++ b/src/components/DeluxeSpotlight.tsx
@@ -6,7 +6,7 @@ const DeluxeSpotlight = () => {
     <section className="py-20 bg-[#FFF8F2]">
       <div className="max-w-3xl mx-auto text-center space-y-6">
         <Crown size={48} className="mx-auto text-[#FFD700]" />
-        <h2 className="text-4xl font-black text-[#4CAF50]">Deluxe Bi-Weekly Plan</h2>
+        <h2 className="text-4xl font-black text-[#4CAF50]">Deluxe Twice-Weekly Plan</h2>
         <p className="text-lg text-gray-700">
           Unlimited dogs, pristine yards, and a fresh start every visit.
         </p>

--- a/src/components/ExitIntentPopup.tsx
+++ b/src/components/ExitIntentPopup.tsx
@@ -26,7 +26,7 @@ const ExitIntentPopup: React.FC<ExitIntentPopupProps> = ({ onClose }) => {
             Wait! Don't Leave Empty-Handed
           </h3>
           <p className="text-white/90">
-            Exclusive offer for Bi-Weekly Deluxe customers only!
+            Exclusive offer for Twice-Weekly Deluxe customers only!
           </p>
         </div>
 
@@ -38,7 +38,7 @@ const ExitIntentPopup: React.FC<ExitIntentPopupProps> = ({ onClose }) => {
               FREE Scented Waste-Bag Dispenser
             </h4>
             <p className="text-gray-600 text-sm">
-              Worth $25 - Yours free when you sign up for Bi-Weekly Deluxe today!
+              Worth $25 - Yours free when you sign up for Twice-Weekly Deluxe today!
             </p>
           </div>
 

--- a/src/components/InteractivePricing.tsx
+++ b/src/components/InteractivePricing.tsx
@@ -13,7 +13,7 @@ const InteractivePricing = () => {
     '7+': 75
   };
 
-  const deluxePrice = 89; // Bi-weekly flat rate
+  const extraVisitFee = 30; // Flat fee for second weekly visit
 
   const calculateWeeklyPrice = (dogs: number) => {
     if (dogs <= 3) return weeklyPricing['1-3'];
@@ -21,11 +21,16 @@ const InteractivePricing = () => {
     return weeklyPricing['7+'];
   };
 
+  const calculateTwiceWeeklyPrice = (dogs: number) => {
+    return calculateWeeklyPrice(dogs) + extraVisitFee;
+  };
+
   const calculateMonthlySavings = (dogs: number) => {
     const weeklyPrice = calculateWeeklyPrice(dogs);
-    const monthlyWeekly = weeklyPrice * 4;
-    const monthlyDeluxe = deluxePrice * 2;
-    return monthlyWeekly - monthlyDeluxe;
+    const twiceWeeklyPrice = calculateTwiceWeeklyPrice(dogs);
+    const monthlyStandardTwoVisits = weeklyPrice * 8;
+    const monthlyDeluxe = twiceWeeklyPrice * 4;
+    return monthlyStandardTwoVisits - monthlyDeluxe;
   };
 
   useEffect(() => {
@@ -111,20 +116,20 @@ const InteractivePricing = () => {
               </ul>
             </div>
 
-            {/* Bi-Weekly Deluxe */}
+            {/* Twice-Weekly Deluxe */}
             <div className="bg-gradient-to-br from-[#FFD700] to-[#FFA500] rounded-2xl p-6 relative overflow-hidden">
               <div className="absolute top-0 right-0 bg-[#FF6B6B] text-white px-3 py-1 rounded-bl-lg text-sm font-bold">
                 POPULAR
               </div>
               
               <div className="text-center mb-4">
-                <h4 className="text-xl font-bold text-gray-800 mb-2">Bi-Weekly Deluxe</h4>
+                <h4 className="text-xl font-bold text-gray-800 mb-2">Twice-Weekly Deluxe</h4>
                 <div className="text-3xl font-black text-gray-800">
-                  ${deluxePrice}
-                  <span className="text-sm font-normal text-gray-600">/bi-weekly</span>
+                  ${calculateTwiceWeeklyPrice(dogCount)}
+                  <span className="text-sm font-normal text-gray-600">/week</span>
                 </div>
                 <p className="text-sm text-gray-600 mt-2">
-                  Monthly: ${deluxePrice * 2}
+                  Monthly: ${calculateTwiceWeeklyPrice(dogCount) * 4}
                 </p>
                 
                 {calculateMonthlySavings(dogCount) > 0 && (
@@ -137,7 +142,7 @@ const InteractivePricing = () => {
               <ul className="space-y-2 text-sm text-gray-800">
                 <li className="flex items-center gap-2">
                   <span className="text-green-600">✓</span>
-                  Bi-weekly service
+                  Twice-weekly service
                 </li>
                 <li className="flex items-center gap-2">
                   <span className="text-green-600">✓</span>

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -34,6 +34,13 @@ const OnboardingWizard = () => {
     }
   ];
 
+  const weeklyPricing = {
+    '1-3': 35,
+    '4-6': 55,
+    '7+': 75
+  };
+  const extraVisitFee = 30;
+
   const plans = [
     {
       id: 'weekly-basic',
@@ -45,11 +52,16 @@ const OnboardingWizard = () => {
     },
     {
       id: 'deluxe',
-      name: 'Bi-Weekly Deluxe',
-      price: 89,
-      period: 'bi-weekly',
+      name: 'Twice-Weekly Deluxe',
+      price:
+        (formData.dogCount <= 3
+          ? weeklyPricing['1-3']
+          : formData.dogCount <= 6
+          ? weeklyPricing['4-6']
+          : weeklyPricing['7+']) + extraVisitFee,
+      period: 'week',
       description: 'Unlimited dogs, premium service',
-      features: ['Bi-weekly service', 'Unlimited dogs', 'Deep sanitization', 'Free dispenser'],
+      features: ['Twice-weekly service', 'Unlimited dogs', 'Deep sanitization', 'Free dispenser'],
       popular: true
     }
   ];

--- a/src/components/ServiceCards.tsx
+++ b/src/components/ServiceCards.tsx
@@ -55,13 +55,13 @@ const ServiceCards = () => {
       popular: false
     },
     {
-      name: "Bi-Weekly Deluxe",
+      name: "Twice-Weekly Deluxe",
       subtitle: "Unlimited Dogs",
-      price: 89,
-      period: "bi-weekly",
+      price: 65,
+      period: "week",
       description: "The ultimate convenience plan",
       features: [
-        "Bi-weekly premium service",
+        "Twice-weekly premium service",
         "Unlimited dogs",
         "Deep sanitization",
         "Free waste bag dispenser",


### PR DESCRIPTION
## Summary
- replace bi-weekly deluxe plan with twice-weekly deluxe plan
- add flat upgrade fee for second visit
- adjust interactive pricing and onboarding wizard calculations
- update customer examples, spotlight, service cards and marketing text

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6878165e8f5c8323b448bb58cc6bb886