### PR TITLE
Update dog counters to max 5

### DIFF
--- a/src/components/InteractivePricing.tsx
+++ b/src/components/InteractivePricing.tsx
@@ -9,16 +9,16 @@ const InteractivePricing = () => {
   // Pricing structure
   const weeklyPricing = {
     '1-3': 35,
-    '4-6': 55,
-    '7+': 75
+    '4-5': 55,
+    '5+': 75
   };
 
   const extraVisitFee = 30; // Flat fee for second weekly visit
 
   const calculateWeeklyPrice = (dogs: number) => {
     if (dogs <= 3) return weeklyPricing['1-3'];
-    if (dogs <= 6) return weeklyPricing['4-6'];
-    return weeklyPricing['7+'];
+    if (dogs <= 5) return weeklyPricing['4-5'];
+    return weeklyPricing['5+'];
   };
 
   const calculateTwiceWeeklyPrice = (dogs: number) => {
@@ -65,7 +65,7 @@ const InteractivePricing = () => {
               How many dogs do you have?
             </h3>
             <div className="flex justify-center items-center gap-4 mb-6">
-              <span className="text-4xl font-black text-[#4CAF50]">{dogCount}</span>
+              <span className="text-4xl font-black text-[#4CAF50]">{dogCount === 5 ? '5+' : dogCount}</span>
               <span className="text-2xl">🐕</span>
             </div>
             
@@ -74,14 +74,14 @@ const InteractivePricing = () => {
               <input
                 type="range"
                 min="1"
-                max="10"
+                max="5"
                 value={dogCount}
-                onChange={(e) => setDogCount(parseInt(e.target.value))}
+                onChange={(e) => setDogCount(Math.min(5, parseInt(e.target.value)))}
                 className="w-full h-4 bg-gray-200 rounded-lg appearance-none cursor-pointer slider"
               />
               <div className="flex justify-between text-sm text-gray-600 mt-2">
                 <span>1 dog</span>
-                <span>10+ dogs</span>
+                <span>5+ dogs</span>
               </div>
             </div>
           </div>
@@ -107,7 +107,7 @@ const InteractivePricing = () => {
                 </li>
                 <li className="flex items-center gap-2">
                   <span className="text-green-500">✓</span>
-                  Up to {dogCount <= 3 ? '3' : dogCount <= 6 ? '6' : '10+'} dogs
+                  Up to {dogCount <= 3 ? '3' : '5+'} dogs
                 </li>
                 <li className="flex items-center gap-2">
                   <span className="text-green-500">✓</span>

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -36,8 +36,8 @@ const OnboardingWizard = () => {
 
   const weeklyPricing = {
     '1-3': 35,
-    '4-6': 55,
-    '7+': 75
+    '4-5': 55,
+    '5+': 75
   };
   const extraVisitFee = 30;
 
@@ -45,9 +45,9 @@ const OnboardingWizard = () => {
     {
       id: 'weekly-basic',
       name: 'Weekly Basic',
-      price: formData.dogCount <= 3 ? 35 : formData.dogCount <= 6 ? 55 : 75,
+      price: formData.dogCount <= 3 ? 35 : formData.dogCount <= 5 ? 55 : 75,
       period: 'week',
-      description: `Perfect for ${formData.dogCount} dog${formData.dogCount > 1 ? 's' : ''}`,
+      description: `Perfect for ${formData.dogCount === 5 ? '5+' : formData.dogCount} dog${formData.dogCount > 1 ? 's' : ''}`,
       features: ['Weekly service', 'Basic cleanup', 'Eco-friendly disposal']
     },
     {
@@ -56,9 +56,9 @@ const OnboardingWizard = () => {
       price:
         (formData.dogCount <= 3
           ? weeklyPricing['1-3']
-          : formData.dogCount <= 6
-          ? weeklyPricing['4-6']
-          : weeklyPricing['7+']) + extraVisitFee,
+          : formData.dogCount <= 5
+          ? weeklyPricing['4-5']
+          : weeklyPricing['5+']) + extraVisitFee,
       period: 'week',
       description: 'Unlimited dogs, premium service',
       features: ['Twice-weekly service', 'Unlimited dogs', 'Deep sanitization', 'Free dispenser'],
@@ -211,17 +211,17 @@ const OnboardingWizard = () => {
                     -
                   </button>
                   <div className="text-4xl font-black text-[#4CAF50]">
-                    {formData.dogCount}
+                    {formData.dogCount === 5 ? '5+' : formData.dogCount}
                   </div>
                   <button
-                    onClick={() => updateFormData('dogCount', formData.dogCount + 1)}
+                    onClick={() => updateFormData('dogCount', Math.min(5, formData.dogCount + 1))}
                     className="w-10 h-10 bg-gray-200 hover:bg-gray-300 rounded-full flex items-center justify-center"
                   >
                     +
                   </button>
                 </div>
                 <p className="text-gray-600 mb-6">
-                  {formData.dogCount} dog{formData.dogCount > 1 ? 's' : ''} selected
+                  {formData.dogCount === 5 ? '5+' : formData.dogCount} dog{formData.dogCount > 1 ? 's' : ''} selected
                 </p>
               </div>
 
@@ -327,7 +327,7 @@ const OnboardingWizard = () => {
                   </div>
                   <div className="flex justify-between">
                     <span>Dogs:</span>
-                    <span>{formData.dogCount}</span>
+                    <span>{formData.dogCount === 5 ? '5+' : formData.dogCount}</span>
                   </div>
                   <div className="flex justify-between">
                     <span>Plan:</span>

--- a/src/components/ServiceCards.tsx
+++ b/src/components/ServiceCards.tsx
@@ -22,13 +22,13 @@ const ServiceCards = () => {
     },
     {
       name: "Standard Weekly",
-      subtitle: "4-6 Dogs",
+      subtitle: "4-5 Dogs",
       price: 55,
       period: "week",
       description: "Great for medium families",
       features: [
         "Weekly waste removal",
-        "Up to 6 dogs",
+        "Up to 5 dogs",
         "Thorough yard cleanup",
         "Priority scheduling",
         "Eco-friendly disposal"
@@ -39,13 +39,13 @@ const ServiceCards = () => {
     },
     {
       name: "Premium Weekly",
-      subtitle: "7+ Dogs",
+      subtitle: "5+ Dogs",
       price: 75,
       period: "week",
       description: "For large dog families",
       features: [
         "Weekly waste removal",
-        "7+ dogs covered",
+        "5+ dogs covered",
         "Deep yard sanitization",
         "Priority scheduling",
         "Eco-friendly disposal"


### PR DESCRIPTION
## Summary
- cap dog count selections at five
- display `5+` for values beyond the limit
- update pricing tiers for 5+ dogs

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68781f89076c8323b2fbd30b74899993