### PR TITLE
Update pricing plans

### DIFF
--- a/src/components/InteractivePricing.tsx
+++ b/src/components/InteractivePricing.tsx
@@ -8,18 +8,21 @@ const InteractivePricing = () => {
 
   // Pricing structure
   const weeklyPricing = {
-    '1-3': 35,
-    '4-5': 55,
-    '5+': 75
+    1: 11.25,
+    2: 17.5,
+    3: 22.5,
+    4: 27.5,
+    5: 30
+  } as const;
+
+  const getWeeklyPrice = (dogs: number) => {
+    if (dogs >= 5) return weeklyPricing[5];
+    return weeklyPricing[dogs as keyof typeof weeklyPricing];
   };
 
-  const extraVisitFee = 30; // Flat fee for second weekly visit
+  const extraVisitFee = 35 / 4; // Additional cost per week for Deluxe plan
 
-  const calculateWeeklyPrice = (dogs: number) => {
-    if (dogs <= 3) return weeklyPricing['1-3'];
-    if (dogs <= 5) return weeklyPricing['4-5'];
-    return weeklyPricing['5+'];
-  };
+  const calculateWeeklyPrice = (dogs: number) => getWeeklyPrice(dogs);
 
   const calculateTwiceWeeklyPrice = (dogs: number) => {
     return calculateWeeklyPrice(dogs) + extraVisitFee;

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -35,17 +35,25 @@ const OnboardingWizard = () => {
   ];
 
   const weeklyPricing = {
-    '1-3': 35,
-    '4-5': 55,
-    '5+': 75
+    1: 11.25,
+    2: 17.5,
+    3: 22.5,
+    4: 27.5,
+    5: 30
+  } as const;
+
+  const getWeeklyPrice = (dogs: number) => {
+    if (dogs >= 5) return weeklyPricing[5];
+    return weeklyPricing[dogs as keyof typeof weeklyPricing];
   };
-  const extraVisitFee = 30;
+
+  const extraVisitFee = 35 / 4; // $35 per month spread over 4 weeks
 
   const plans = [
     {
       id: 'weekly-basic',
       name: 'Weekly Basic',
-      price: formData.dogCount <= 3 ? 35 : formData.dogCount <= 5 ? 55 : 75,
+      price: getWeeklyPrice(formData.dogCount),
       period: 'week',
       description: `Perfect for ${formData.dogCount === 5 ? '5+' : formData.dogCount} dog${formData.dogCount > 1 ? 's' : ''}`,
       features: ['Weekly service', 'Basic cleanup', 'Eco-friendly disposal']
@@ -53,12 +61,7 @@ const OnboardingWizard = () => {
     {
       id: 'deluxe',
       name: 'Twice-Weekly Deluxe',
-      price:
-        (formData.dogCount <= 3
-          ? weeklyPricing['1-3']
-          : formData.dogCount <= 5
-          ? weeklyPricing['4-5']
-          : weeklyPricing['5+']) + extraVisitFee,
+      price: getWeeklyPrice(formData.dogCount) + extraVisitFee,
       period: 'week',
       description: 'Unlimited dogs, premium service',
       features: ['Twice-weekly service', 'Unlimited dogs', 'Deep sanitization', 'Free dispenser'],

--- a/src/components/ServiceCards.tsx
+++ b/src/components/ServiceCards.tsx
@@ -5,13 +5,13 @@ const ServiceCards = () => {
   const services = [
     {
       name: "Basic Weekly",
-      subtitle: "1-3 Dogs",
-      price: 35,
+      subtitle: "1 Dog",
+      price: 11.25,
       period: "week",
-      description: "Perfect for small households",
+      description: "Perfect for single pup households",
       features: [
         "Weekly waste removal",
-        "Up to 3 dogs",
+        "1 dog",
         "Basic yard cleanup",
         "Reliable service",
         "Eco-friendly disposal"
@@ -22,13 +22,13 @@ const ServiceCards = () => {
     },
     {
       name: "Standard Weekly",
-      subtitle: "4-5 Dogs",
-      price: 55,
+      subtitle: "2 Dogs",
+      price: 17.5,
       period: "week",
-      description: "Great for medium families",
+      description: "Ideal for two furry friends",
       features: [
         "Weekly waste removal",
-        "Up to 5 dogs",
+        "2 dogs",
         "Thorough yard cleanup",
         "Priority scheduling",
         "Eco-friendly disposal"
@@ -39,13 +39,13 @@ const ServiceCards = () => {
     },
     {
       name: "Premium Weekly",
-      subtitle: "5+ Dogs",
-      price: 75,
+      subtitle: "3+ Dogs",
+      price: 22.5,
       period: "week",
-      description: "For large dog families",
+      description: "For homes with three or more dogs",
       features: [
         "Weekly waste removal",
-        "5+ dogs covered",
+        "3+ dogs",
         "Deep yard sanitization",
         "Priority scheduling",
         "Eco-friendly disposal"
@@ -56,10 +56,10 @@ const ServiceCards = () => {
     },
     {
       name: "Twice-Weekly Deluxe",
-      subtitle: "Unlimited Dogs",
-      price: 65,
+      subtitle: "Add-On",
+      price: 8.75,
       period: "week",
-      description: "The ultimate convenience plan",
+      description: "Flat $35/month extra for a second visit",
       features: [
         "Twice-weekly premium service",
         "Unlimited dogs",


### PR DESCRIPTION
## Summary
- adjust weekly pricing tables based on new monthly rates
- update deluxe add-on fee and plan calculations
- refresh static service card pricing

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6878368b1cec8323b31df00c08fc0b05