### PR TITLE
Allow favicon override

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# DoggiePoo2
+
+This project is built with Vite and React.
+
+## Changing the Web Icon
+
+You can customize the site's favicon by setting the `VITE_SITE_ICON` environment variable to the path of your preferred icon.
+
+Example `.env`:
+
+```
+VITE_SITE_ICON=/custom-icon.svg
+```
+
+When running `vite` or building the project, this value will be used to set the favicon. If `VITE_SITE_ICON` is not provided, the default `vite.svg` icon will be used.
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,14 @@ import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
 
+// Dynamically set the favicon based on an environment variable.
+// Falls back to the default Vite icon if none provided.
+const iconPath = import.meta.env.VITE_SITE_ICON || '/vite.svg';
+const favicon = document.querySelector<HTMLLinkElement>("link[rel~='icon']");
+if (favicon) {
+  favicon.href = iconPath;
+}
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />


### PR DESCRIPTION
## Summary
- configure site favicon via `VITE_SITE_ICON` env variable
- document favicon customization

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68783715dddc8323a35d59fba9ba5c1d