### PR TITLE
Refine site color palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
         font-family: 'Raleway', sans-serif;
       }
       .slider {
-        background: linear-gradient(to right, #4CAF50, #45a049);
+        background: linear-gradient(to right, #5B84B1, #4A698B);
         height: 8px;
         border-radius: 4px;
         outline: none;
@@ -27,7 +27,7 @@
         appearance: none;
         width: 20px;
         height: 20px;
-        background: #FFD700;
+        background: #FFCF8B;
         border-radius: 50%;
         cursor: pointer;
         box-shadow: 0 2px 4px rgba(0,0,0,0.2);
@@ -35,7 +35,7 @@
       .slider::-moz-range-thumb {
         width: 20px;
         height: 20px;
-        background: #FFD700;
+        background: #FFCF8B;
         border-radius: 50%;
         cursor: pointer;
         border: none;

--- a/src/components/BeforeAfterGallery.tsx
+++ b/src/components/BeforeAfterGallery.tsx
@@ -44,7 +44,7 @@ const BeforeAfterGallery = () => {
   };
 
   return (
-    <section id="before-after-gallery" className="py-20 bg-gradient-to-br from-[#9DE5FF] to-[#00B4FF]">
+    <section id="before-after-gallery" className="py-20 bg-gradient-to-br from-[#D0E5F2] to-[#88B0BF]">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
           <h2 className="text-4xl sm:text-5xl font-black text-white mb-4">
@@ -69,7 +69,7 @@ const BeforeAfterGallery = () => {
                   </div>
 
                   {/* Before/After Slider */}
-                  <div className="relative h-64 bg-gradient-to-r from-[#A8F483] to-[#4CAF50] rounded-2xl overflow-hidden">
+                  <div className="relative h-64 bg-gradient-to-r from-[#BFD8E2] to-[#5B84B1] rounded-2xl overflow-hidden">
                     {/* Before side */}
                     <div 
                       className="absolute inset-0 bg-gradient-to-br from-orange-400 to-red-500 flex items-center justify-center text-6xl transition-all duration-300"
@@ -85,7 +85,7 @@ const BeforeAfterGallery = () => {
 
                     {/* After side */}
                     <div 
-                      className="absolute inset-0 bg-gradient-to-br from-[#4CAF50] to-[#45a049] flex items-center justify-center text-6xl transition-all duration-300"
+                      className="absolute inset-0 bg-gradient-to-br from-[#5B84B1] to-[#4A698B] flex items-center justify-center text-6xl transition-all duration-300"
                       style={{ 
                         clipPath: `polygon(${sliderPositions[index]}% 0, 100% 0, 100% 100%, ${sliderPositions[index]}% 100%)` 
                       }}
@@ -102,7 +102,7 @@ const BeforeAfterGallery = () => {
                       style={{ left: `${sliderPositions[index]}%` }}
                     >
                       <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-8 h-8 bg-white rounded-full shadow-lg flex items-center justify-center">
-                        <div className="w-4 h-4 bg-[#4CAF50] rounded-full"></div>
+                        <div className="w-4 h-4 bg-[#5B84B1] rounded-full"></div>
                       </div>
                     </div>
 

--- a/src/components/ComicStrip.tsx
+++ b/src/components/ComicStrip.tsx
@@ -77,7 +77,7 @@ const ComicStrip = () => {
   };
 
   return (
-    <section id="comic-strip" className="py-20 bg-gradient-to-r from-[#9DE5FF] to-[#A8F483]">
+    <section id="comic-strip" className="py-20 bg-gradient-to-r from-[#D0E5F2] to-[#BFD8E2]">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-12">
           <h2 className="text-4xl sm:text-5xl font-black text-white mb-4">
@@ -101,7 +101,7 @@ const ComicStrip = () => {
                     <div className="grid lg:grid-cols-2 gap-8 items-center">
                       {/* Frame Visual */}
                       <div className="relative">
-                        <div className="w-full h-80 bg-gradient-to-br from-[#A8F483] to-[#4CAF50] rounded-2xl flex items-center justify-center shadow-lg">
+                        <div className="w-full h-80 bg-gradient-to-br from-[#BFD8E2] to-[#5B84B1] rounded-2xl flex items-center justify-center shadow-lg">
                           <div className="text-8xl sm:text-9xl transform hover:scale-110 transition-transform duration-300">
                             {frame.image}
                           </div>
@@ -109,18 +109,18 @@ const ComicStrip = () => {
                         
                         {/* Speech bubble */}
                         <div className="absolute -bottom-4 left-1/2 transform -translate-x-1/2">
-                          <div className="bg-white rounded-full px-6 py-3 shadow-lg border-4 border-[#FFD700]">
+                          <div className="bg-white rounded-full px-6 py-3 shadow-lg border-4 border-[#FFCF8B]">
                             <p className="text-sm font-bold text-gray-800 whitespace-nowrap">
                               {frame.caption}
                             </p>
                           </div>
-                          <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 w-4 h-4 bg-white border-l-4 border-b-4 border-[#FFD700] rotate-45"></div>
+                          <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 w-4 h-4 bg-white border-l-4 border-b-4 border-[#FFCF8B] rotate-45"></div>
                         </div>
                       </div>
 
                       {/* Frame Content */}
                       <div className="text-center lg:text-left space-y-6">
-                        <div className="inline-block px-4 py-2 bg-[#FFD700] rounded-full">
+                        <div className="inline-block px-4 py-2 bg-[#FFCF8B] rounded-full">
                           <span className="text-sm font-bold text-gray-800">Frame {frame.id}</span>
                         </div>
                         <h3 className="text-3xl sm:text-4xl font-black text-gray-800">
@@ -131,7 +131,7 @@ const ComicStrip = () => {
                         </p>
                         
                         {index === frames.length - 1 && (
-                          <button className="group relative px-8 py-4 bg-[#4CAF50] hover:bg-[#45a049] text-white font-bold text-lg rounded-full transition-all duration-300 transform hover:scale-105 hover:shadow-xl">
+                          <button className="group relative px-8 py-4 bg-[#5B84B1] hover:bg-[#4A698B] text-white font-bold text-lg rounded-full transition-all duration-300 transform hover:scale-105 hover:shadow-xl">
                             <span className="relative z-10">Book Twice-Weekly Deluxe</span>
                           <div className="absolute inset-0 bg-white/20 rounded-full scale-0 group-hover:scale-100 transition-transform duration-300"></div>
                           </button>
@@ -163,7 +163,7 @@ const ComicStrip = () => {
                   onClick={() => goToFrame(index)}
                   className={`w-4 h-4 rounded-full transition-all duration-300 ${
                     index === currentFrame 
-                      ? 'bg-[#FFD700] scale-125 shadow-lg' 
+                      ? 'bg-[#FFCF8B] scale-125 shadow-lg' 
                       : 'bg-white/70 hover:bg-white hover:scale-110'
                   }`}
                 />

--- a/src/components/CustomerLove.tsx
+++ b/src/components/CustomerLove.tsx
@@ -118,7 +118,7 @@ const CustomerLove = () => {
             
             <div className="relative bg-white rounded-3xl shadow-2xl overflow-hidden">
               {/* Video placeholder */}
-              <div className="relative h-64 bg-gradient-to-br from-[#4CAF50] to-[#45a049] flex items-center justify-center">
+              <div className="relative h-64 bg-gradient-to-br from-[#5B84B1] to-[#4A698B] flex items-center justify-center">
                 <div className="text-center text-white">
                   <div className="text-6xl mb-4">{currentTest.video}</div>
                   <button className="flex items-center gap-2 px-6 py-3 bg-white/20 hover:bg-white/30 rounded-full transition-all duration-300 backdrop-blur-sm">
@@ -131,7 +131,7 @@ const CustomerLove = () => {
               {/* Testimonial content */}
               <div className="p-6">
                 <div className="flex items-center gap-4 mb-4">
-                  <div className="w-12 h-12 bg-gradient-to-br from-[#FFD700] to-[#FFA500] rounded-full flex items-center justify-center">
+                  <div className="w-12 h-12 bg-gradient-to-br from-[#FFCF8B] to-[#F6B26B] rounded-full flex items-center justify-center">
                     <span className="text-white font-bold text-lg">
                       {currentTest.name.charAt(0)}
                     </span>
@@ -150,7 +150,7 @@ const CustomerLove = () => {
                         size={16}
                         className={`${
                           starAnimation ? 'animate-pulse' : ''
-                        } text-[#FFD700] fill-current`}
+                        } text-[#FFCF8B] fill-current`}
                       />
                     ))}
                   </div>
@@ -160,7 +160,7 @@ const CustomerLove = () => {
                 </div>
 
                 <div className="relative">
-                  <Quote size={24} className="absolute -top-2 -left-2 text-[#4CAF50] opacity-50" />
+                  <Quote size={24} className="absolute -top-2 -left-2 text-[#5B84B1] opacity-50" />
                   <p className="text-gray-700 leading-relaxed pl-6">
                     {currentTest.quote}
                   </p>
@@ -185,7 +185,7 @@ const CustomerLove = () => {
                     onClick={() => setCurrentTestimonial(index)}
                     className={`w-3 h-3 rounded-full transition-all duration-300 ${
                       index === currentTestimonial 
-                        ? 'bg-[#4CAF50] scale-125' 
+                        ? 'bg-[#5B84B1] scale-125' 
                         : 'bg-gray-300'
                     }`}
                   />
@@ -214,13 +214,13 @@ const CustomerLove = () => {
                   key={index}
                   className={`bg-white rounded-2xl p-6 shadow-lg transition-all duration-500 ${
                     index === currentReview 
-                      ? 'scale-105 border-2 border-[#4CAF50]' 
+                      ? 'scale-105 border-2 border-[#5B84B1]' 
                       : 'scale-100 opacity-80'
                   }`}
                 >
                   <div className="flex items-center justify-between mb-3">
                     <div className="flex items-center gap-3">
-                      <div className="w-10 h-10 bg-gradient-to-br from-[#A8F483] to-[#4CAF50] rounded-full flex items-center justify-center">
+                      <div className="w-10 h-10 bg-gradient-to-br from-[#BFD8E2] to-[#5B84B1] rounded-full flex items-center justify-center">
                         <span className="text-white font-bold text-sm">
                           {review.name.charAt(0)}
                         </span>
@@ -236,7 +236,7 @@ const CustomerLove = () => {
                         <Star
                           key={i}
                           size={14}
-                          className="text-[#FFD700] fill-current"
+                          className="text-[#FFCF8B] fill-current"
                         />
                       ))}
                     </div>
@@ -250,7 +250,7 @@ const CustomerLove = () => {
             </div>
 
             {/* Overall rating */}
-            <div className="bg-gradient-to-r from-[#4CAF50] to-[#45a049] rounded-2xl p-6 text-white text-center">
+            <div className="bg-gradient-to-r from-[#5B84B1] to-[#4A698B] rounded-2xl p-6 text-white text-center">
               <div className="text-3xl font-black mb-2">4.9 ⭐</div>
               <p className="text-sm opacity-90">Average rating from 500+ customers</p>
               <div className="mt-4 flex justify-center">
@@ -259,7 +259,7 @@ const CustomerLove = () => {
                     <Star
                       key={i}
                       size={20}
-                      className="text-[#FFD700] fill-current"
+                      className="text-[#FFCF8B] fill-current"
                     />
                   ))}
                 </div>

--- a/src/components/DeluxeSpotlight.tsx
+++ b/src/components/DeluxeSpotlight.tsx
@@ -5,8 +5,8 @@ const DeluxeSpotlight = () => {
   return (
     <section className="py-20 bg-[#FFF8F2]">
       <div className="max-w-3xl mx-auto text-center space-y-6">
-        <Crown size={48} className="mx-auto text-[#FFD700]" />
-        <h2 className="text-4xl font-black text-[#4CAF50]">Deluxe Twice-Weekly Plan</h2>
+        <Crown size={48} className="mx-auto text-[#FFCF8B]" />
+        <h2 className="text-4xl font-black text-[#5B84B1]">Deluxe Twice-Weekly Plan</h2>
         <p className="text-lg text-gray-700">
           Unlimited dogs, pristine yards, and a fresh start every visit.
         </p>

--- a/src/components/ExitIntentPopup.tsx
+++ b/src/components/ExitIntentPopup.tsx
@@ -18,7 +18,7 @@ const ExitIntentPopup: React.FC<ExitIntentPopupProps> = ({ onClose }) => {
         </button>
 
         {/* Header */}
-        <div className="bg-gradient-to-r from-[#FFD700] to-[#FFA500] p-6 text-center">
+        <div className="bg-gradient-to-r from-[#FFCF8B] to-[#F6B26B] p-6 text-center">
           <div className="w-20 h-20 bg-white/20 rounded-full flex items-center justify-center mx-auto mb-4">
             <Gift size={32} className="text-white" />
           </div>
@@ -45,19 +45,19 @@ const ExitIntentPopup: React.FC<ExitIntentPopupProps> = ({ onClose }) => {
           {/* Features */}
           <div className="space-y-3 mb-6">
             <div className="flex items-center gap-3">
-              <div className="w-5 h-5 bg-[#4CAF50] rounded-full flex items-center justify-center">
+              <div className="w-5 h-5 bg-[#5B84B1] rounded-full flex items-center justify-center">
                 <span className="text-white text-xs">✓</span>
               </div>
               <span className="text-sm text-gray-700">Premium scented bags included</span>
             </div>
             <div className="flex items-center gap-3">
-              <div className="w-5 h-5 bg-[#4CAF50] rounded-full flex items-center justify-center">
+              <div className="w-5 h-5 bg-[#5B84B1] rounded-full flex items-center justify-center">
                 <span className="text-white text-xs">✓</span>
               </div>
               <span className="text-sm text-gray-700">Weather-resistant mounting</span>
             </div>
             <div className="flex items-center gap-3">
-              <div className="w-5 h-5 bg-[#4CAF50] rounded-full flex items-center justify-center">
+              <div className="w-5 h-5 bg-[#5B84B1] rounded-full flex items-center justify-center">
                 <span className="text-white text-xs">✓</span>
               </div>
               <span className="text-sm text-gray-700">Unlimited dogs covered</span>
@@ -65,7 +65,7 @@ const ExitIntentPopup: React.FC<ExitIntentPopupProps> = ({ onClose }) => {
           </div>
 
           {/* Urgency */}
-          <div className="bg-[#FFD700] rounded-lg p-4 mb-6">
+          <div className="bg-[#FFCF8B] rounded-lg p-4 mb-6">
             <div className="flex items-center gap-2 justify-center">
               <Star size={16} className="text-gray-800" />
               <span className="text-sm font-bold text-gray-800">
@@ -75,7 +75,7 @@ const ExitIntentPopup: React.FC<ExitIntentPopupProps> = ({ onClose }) => {
           </div>
 
           {/* CTA */}
-          <button className="w-full py-3 bg-gradient-to-r from-[#4CAF50] to-[#45a049] hover:from-[#45a049] hover:to-[#4CAF50] text-white font-bold rounded-full transition-all duration-300 transform hover:scale-105">
+          <button className="w-full py-3 bg-gradient-to-r from-[#5B84B1] to-[#4A698B] hover:from-[#4A698B] hover:to-[#5B84B1] text-white font-bold rounded-full transition-all duration-300 transform hover:scale-105">
             Claim My Free Dispenser + Start Deluxe
           </button>
           

--- a/src/components/FAQ.tsx
+++ b/src/components/FAQ.tsx
@@ -74,11 +74,11 @@ const FAQ = () => {
                   className="w-full px-6 py-4 flex items-center justify-between text-left hover:bg-gray-50 transition-colors duration-200"
                 >
                   <div className="flex items-center gap-4">
-                    <div className="w-12 h-12 bg-gradient-to-br from-[#4CAF50] to-[#45a049] rounded-full flex items-center justify-center">
+                    <div className="w-12 h-12 bg-gradient-to-br from-[#5B84B1] to-[#4A698B] rounded-full flex items-center justify-center">
                       <Icon size={20} className="text-white" />
                     </div>
                     <div>
-                      <span className="inline-block px-3 py-1 bg-[#A8F483] text-[#4CAF50] text-xs font-bold rounded-full mb-1">
+                      <span className="inline-block px-3 py-1 bg-[#BFD8E2] text-[#5B84B1] text-xs font-bold rounded-full mb-1">
                         {faq.category}
                       </span>
                       <h3 className="text-lg font-bold text-gray-800">
@@ -115,7 +115,7 @@ const FAQ = () => {
 
         {/* Contact CTA */}
         <div className="mt-16 text-center">
-          <div className="bg-gradient-to-r from-[#4CAF50] to-[#45a049] rounded-3xl p-8 text-white">
+          <div className="bg-gradient-to-r from-[#5B84B1] to-[#4A698B] rounded-3xl p-8 text-white">
             <h3 className="text-2xl font-bold mb-4">
               Still have questions?
             </h3>
@@ -123,7 +123,7 @@ const FAQ = () => {
               We're here to help! Our friendly team is ready to answer any questions about our service.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <button className="px-8 py-3 bg-white text-[#4CAF50] font-bold rounded-full hover:bg-gray-100 transition-all duration-300">
+              <button className="px-8 py-3 bg-white text-[#5B84B1] font-bold rounded-full hover:bg-gray-100 transition-all duration-300">
                 Chat with Us
               </button>
               <button className="px-8 py-3 bg-white/20 text-white font-bold rounded-full hover:bg-white/30 transition-all duration-300">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,7 +3,7 @@ import { Facebook, Twitter, Instagram, Mail, Phone, MapPin } from 'lucide-react'
 
 const Footer = () => {
   return (
-    <footer className="relative py-20 bg-gradient-to-r from-[#4CAF50] to-[#45a049] overflow-hidden">
+    <footer className="relative py-20 bg-gradient-to-r from-[#5B84B1] to-[#4A698B] overflow-hidden">
       {/* Paw wave border */}
         <div className="absolute top-0 left-0 right-0 h-8 bg-[#FFF8F2]"></div>
 
@@ -16,7 +16,7 @@ const Footer = () => {
           <p className="text-xl text-white/90 max-w-2xl mx-auto mb-8">
             Join hundreds of happy customers who never worry about yard cleanup again
           </p>
-          <button className="group relative px-8 py-4 bg-[#FFD700] hover:bg-[#FFA500] text-gray-800 font-bold text-lg rounded-full transition-all duration-300 transform hover:scale-105 hover:shadow-2xl">
+          <button className="group relative px-8 py-4 bg-[#FFCF8B] hover:bg-[#F6B26B] text-gray-800 font-bold text-lg rounded-full transition-all duration-300 transform hover:scale-105 hover:shadow-2xl">
             <span className="relative z-10">Start Your Service Today</span>
             <div className="absolute inset-0 bg-white/20 rounded-full scale-0 group-hover:scale-100 transition-transform duration-300" />
           </button>
@@ -27,7 +27,7 @@ const Footer = () => {
           {/* Company info */}
           <div className="lg:col-span-2">
             <div className="flex items-center gap-3 mb-6">
-              <div className="w-16 h-16 bg-[#FFD700] rounded-full flex items-center justify-center">
+              <div className="w-16 h-16 bg-[#FFCF8B] rounded-full flex items-center justify-center">
                 <span className="text-2xl">🦸‍♂️</span>
               </div>
               <div>
@@ -101,8 +101,8 @@ const Footer = () => {
       </div>
 
       {/* Decorative elements */}
-      <div className="absolute bottom-0 left-0 w-32 h-32 bg-[#FFD700] rounded-full opacity-10 transform translate-x-[-50%] translate-y-[50%]"></div>
-      <div className="absolute top-0 right-0 w-24 h-24 bg-[#9DE5FF] rounded-full opacity-10 transform translate-x-[50%] translate-y-[-50%]"></div>
+      <div className="absolute bottom-0 left-0 w-32 h-32 bg-[#FFCF8B] rounded-full opacity-10 transform translate-x-[-50%] translate-y-[50%]"></div>
+      <div className="absolute top-0 right-0 w-24 h-24 bg-[#D0E5F2] rounded-full opacity-10 transform translate-x-[50%] translate-y-[-50%]"></div>
     </footer>
   );
 };

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -27,7 +27,7 @@ const Hero = () => {
   return (
     <section id="hero" className="relative min-h-screen flex items-center justify-center overflow-hidden">
       {/* Animated background */}
-      <div className="absolute inset-0 bg-gradient-to-br from-[#A8F483] via-[#4CAF50] to-[#00B4FF]">
+      <div className="absolute inset-0 bg-gradient-to-br from-[#BFD8E2] via-[#5B84B1] to-[#88B0BF]">
         <div className="absolute inset-0 bg-white/20 opacity-20 animate-pulse"></div>
       </div>
 
@@ -38,7 +38,7 @@ const Hero = () => {
             <div className="space-y-4">
               <h1 className="text-5xl sm:text-6xl lg:text-7xl font-black text-white leading-tight">
                 Never Step in It
-                <span className="block text-[#FFD700] drop-shadow-lg">Again.</span>
+                <span className="block text-[#FFCF8B] drop-shadow-lg">Again.</span>
               </h1>
               <p className="text-xl sm:text-2xl text-white/90 max-w-2xl">
                 Leave the doo to our crew! Professional dog waste removal that keeps your yard pristine and your paws clean.
@@ -46,7 +46,7 @@ const Hero = () => {
             </div>
 
             <div className="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start">
-              <button className="group relative px-8 py-4 bg-[#FFD700] hover:bg-[#FFC107] text-black font-bold text-lg rounded-full transition-all duration-300 transform hover:scale-105 hover:shadow-2xl">
+              <button className="group relative px-8 py-4 bg-[#FFCF8B] hover:bg-[#E7B75F] text-black font-bold text-lg rounded-full transition-all duration-300 transform hover:scale-105 hover:shadow-2xl">
                 <span className="relative z-10">Start My Plan</span>
                 <div className="absolute inset-0 bg-white/20 rounded-full scale-0 group-hover:scale-100 transition-transform duration-300"></div>
               </button>
@@ -69,7 +69,7 @@ const Hero = () => {
               {/* Captain Scoop */}
               <div className="relative w-80 h-80 mx-auto mb-8">
                 <div
-                  className="absolute inset-0 bg-[#FFD700] opacity-20 animate-ping"
+                  className="absolute inset-0 bg-[#FFCF8B] opacity-20 animate-ping"
                   style={{ clipPath: 'polygon(25% 5%, 75% 5%, 100% 50%, 75% 95%, 25% 95%, 0% 50%)' }}
                 />
                 <div
@@ -78,7 +78,7 @@ const Hero = () => {
                 >
                   <div className="text-8xl">🦸‍♂️🐕</div>
                   <div
-                    className={`absolute -top-6 -right-6 w-16 h-16 bg-[#FF6B6B] flex items-center justify-center text-2xl transition-transform duration-300 ${isWagging ? 'animate-spin' : ''}`}
+                    className={`absolute -top-6 -right-6 w-16 h-16 bg-[#E27D60] flex items-center justify-center text-2xl transition-transform duration-300 ${isWagging ? 'animate-spin' : ''}`}
                     style={{ clipPath: 'polygon(50% 0%, 61% 35%, 98% 35%, 68% 57%, 79% 91%, 50% 70%, 21% 91%, 32% 57%, 2% 35%, 39% 35%)' }}
                   >
                     🚀
@@ -88,11 +88,11 @@ const Hero = () => {
 
               {/* Geometric accents */}
               <div
-                className="absolute -top-8 -left-8 w-12 h-12 bg-[#9DE5FF] opacity-70"
+                className="absolute -top-8 -left-8 w-12 h-12 bg-[#D0E5F2] opacity-70"
                 style={{ clipPath: 'polygon(50% 0%, 0% 100%, 100% 100%)' }}
               />
               <div
-                className="absolute -bottom-4 -right-8 w-10 h-10 bg-[#A8F483] opacity-70"
+                className="absolute -bottom-4 -right-8 w-10 h-10 bg-[#BFD8E2] opacity-70"
                 style={{ clipPath: 'polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%)' }}
               />
             </div>
@@ -100,7 +100,7 @@ const Hero = () => {
             {/* Pristine yard visualization */}
             <div className="mt-8 p-6 bg-white/90 rounded-3xl backdrop-blur-sm shadow-xl">
               <div className="flex items-center gap-4 mb-4">
-                <div className="w-12 h-12 bg-[#4CAF50] rounded-full flex items-center justify-center">
+                <div className="w-12 h-12 bg-[#5B84B1] rounded-full flex items-center justify-center">
                   <span className="text-white font-bold">✓</span>
                 </div>
                 <div>
@@ -109,9 +109,9 @@ const Hero = () => {
                 </div>
               </div>
               <div className="grid grid-cols-3 gap-2">
-                <div className="h-12 bg-[#4CAF50] rounded-lg flex items-center justify-center">🌱</div>
-                <div className="h-12 bg-[#A8F483] rounded-lg flex items-center justify-center">🌿</div>
-                <div className="h-12 bg-[#4CAF50] rounded-lg flex items-center justify-center">🌱</div>
+                <div className="h-12 bg-[#5B84B1] rounded-lg flex items-center justify-center">🌱</div>
+                <div className="h-12 bg-[#BFD8E2] rounded-lg flex items-center justify-center">🌿</div>
+                <div className="h-12 bg-[#5B84B1] rounded-lg flex items-center justify-center">🌱</div>
               </div>
             </div>
           </div>

--- a/src/components/HowItWorks.tsx
+++ b/src/components/HowItWorks.tsx
@@ -10,19 +10,19 @@ const HowItWorks = () => {
       icon: Calendar,
       title: "Book",
       description: "Choose your plan and schedule in under 60 seconds",
-      color: "from-[#FFD700] to-[#FFA500]"
+      color: "from-[#FFCF8B] to-[#F6B26B]"
     },
     {
       icon: Truck,
       title: "Scoop",
       description: "Our certified crew arrives and transforms your yard",
-      color: "from-[#4CAF50] to-[#45a049]"
+      color: "from-[#5B84B1] to-[#4A698B]"
     },
     {
       icon: Smile,
       title: "Smile",
       description: "Enjoy your pristine, poop-free paradise",
-      color: "from-[#00B4FF] to-[#0099CC]"
+      color: "from-[#88B0BF] to-[#7EB7DF]"
     }
   ];
 
@@ -76,7 +76,7 @@ const HowItWorks = () => {
           <div className="absolute top-1/2 left-0 right-0 h-2 transform -translate-y-1/2">
             <div className="relative h-full bg-gray-200 rounded-full overflow-hidden">
               <div 
-                className="absolute top-0 left-0 h-full bg-gradient-to-r from-[#FFD700] via-[#4CAF50] to-[#00B4FF] transition-all duration-1000 ease-out"
+                className="absolute top-0 left-0 h-full bg-gradient-to-r from-[#FFCF8B] via-[#5B84B1] to-[#88B0BF] transition-all duration-1000 ease-out"
                 style={{ width: `${pathProgress}%` }}
               />
             </div>
@@ -130,13 +130,13 @@ const HowItWorks = () => {
           </div>
 
           {/* Decorative elements */}
-          <div className="absolute -top-8 left-1/4 w-16 h-16 bg-[#A8F483] rounded-full opacity-20 animate-pulse" />
-          <div className="absolute -bottom-8 right-1/4 w-12 h-12 bg-[#9DE5FF] rounded-full opacity-20 animate-bounce" />
+          <div className="absolute -top-8 left-1/4 w-16 h-16 bg-[#BFD8E2] rounded-full opacity-20 animate-pulse" />
+          <div className="absolute -bottom-8 right-1/4 w-12 h-12 bg-[#D0E5F2] rounded-full opacity-20 animate-bounce" />
         </div>
 
         {/* CTA */}
         <div className="text-center mt-16">
-          <button className="group relative px-8 py-4 bg-gradient-to-r from-[#4CAF50] to-[#45a049] hover:from-[#45a049] hover:to-[#4CAF50] text-white font-bold text-lg rounded-full transition-all duration-300 transform hover:scale-105 hover:shadow-xl">
+          <button className="group relative px-8 py-4 bg-gradient-to-r from-[#5B84B1] to-[#4A698B] hover:from-[#4A698B] hover:to-[#5B84B1] text-white font-bold text-lg rounded-full transition-all duration-300 transform hover:scale-105 hover:shadow-xl">
             <span className="relative z-10">Start Your Service</span>
             <div className="absolute inset-0 bg-white/20 rounded-full scale-0 group-hover:scale-100 transition-transform duration-300" />
           </button>

--- a/src/components/InteractivePricing.tsx
+++ b/src/components/InteractivePricing.tsx
@@ -50,7 +50,7 @@ const InteractivePricing = () => {
   }, [dogCount, showConfetti]);
 
   return (
-    <section id="interactive-pricing" className="py-20 bg-gradient-to-br from-[#A8F483] to-[#4CAF50]">
+    <section id="interactive-pricing" className="py-20 bg-gradient-to-br from-[#BFD8E2] to-[#5B84B1]">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-12">
           <h2 className="text-4xl sm:text-5xl font-black text-white mb-4">
@@ -68,7 +68,7 @@ const InteractivePricing = () => {
               How many dogs do you have?
             </h3>
             <div className="flex justify-center items-center gap-4 mb-6">
-              <span className="text-4xl font-black text-[#4CAF50]">{dogCount === 5 ? '5+' : dogCount}</span>
+              <span className="text-4xl font-black text-[#5B84B1]">{dogCount === 5 ? '5+' : dogCount}</span>
               <span className="text-2xl">🐕</span>
             </div>
             
@@ -120,8 +120,8 @@ const InteractivePricing = () => {
             </div>
 
             {/* Twice-Weekly Deluxe */}
-            <div className="bg-gradient-to-br from-[#FFD700] to-[#FFA500] rounded-2xl p-6 relative overflow-hidden">
-              <div className="absolute top-0 right-0 bg-[#FF6B6B] text-white px-3 py-1 rounded-bl-lg text-sm font-bold">
+            <div className="bg-gradient-to-br from-[#FFCF8B] to-[#F6B26B] rounded-2xl p-6 relative overflow-hidden">
+              <div className="absolute top-0 right-0 bg-[#E27D60] text-white px-3 py-1 rounded-bl-lg text-sm font-bold">
                 POPULAR
               </div>
               
@@ -165,7 +165,7 @@ const InteractivePricing = () => {
 
           {/* Savings Meter */}
           {dogCount >= 4 && (
-            <div className="mt-8 p-6 bg-gradient-to-r from-[#4CAF50] to-[#45a049] rounded-2xl text-white">
+            <div className="mt-8 p-6 bg-gradient-to-r from-[#5B84B1] to-[#4A698B] rounded-2xl text-white">
               <div className="text-center mb-4">
                 <h4 className="text-xl font-bold mb-2">💰 Savings Meter</h4>
                 <p className="text-sm opacity-90">
@@ -175,7 +175,7 @@ const InteractivePricing = () => {
               
               <div className="relative bg-white/20 rounded-full h-6 overflow-hidden">
                 <div 
-                  className="absolute top-0 left-0 h-full bg-gradient-to-r from-[#FFD700] to-[#FFA500] transition-all duration-1000 ease-out flex items-center justify-end pr-2"
+                  className="absolute top-0 left-0 h-full bg-gradient-to-r from-[#FFCF8B] to-[#F6B26B] transition-all duration-1000 ease-out flex items-center justify-end pr-2"
                   style={{ width: `${savingsMeter}%` }}
                 >
                   <DollarSign size={16} className="text-white" />
@@ -183,7 +183,7 @@ const InteractivePricing = () => {
               </div>
               
               <div className="text-center mt-4">
-                <button className="group relative px-8 py-3 bg-[#FFD700] hover:bg-[#FFA500] text-gray-800 font-bold rounded-full transition-all duration-300 transform hover:scale-105">
+                <button className="group relative px-8 py-3 bg-[#FFCF8B] hover:bg-[#F6B26B] text-gray-800 font-bold rounded-full transition-all duration-300 transform hover:scale-105">
                   <span className="relative z-10">Upgrade to Deluxe</span>
                   <div className="absolute inset-0 bg-white/20 rounded-full scale-0 group-hover:scale-100 transition-transform duration-300" />
                 </button>
@@ -199,7 +199,7 @@ const InteractivePricing = () => {
               {[...Array(20)].map((_, i) => (
                 <div
                   key={i}
-                  className="absolute w-4 h-4 bg-[#4CAF50] rounded-full animate-ping"
+                  className="absolute w-4 h-4 bg-[#5B84B1] rounded-full animate-ping"
                   style={{
                     left: `${Math.random() * 200 - 100}px`,
                     top: `${Math.random() * 200 - 100}px`,

--- a/src/components/NavTabs.tsx
+++ b/src/components/NavTabs.tsx
@@ -14,7 +14,7 @@ const NavTabs = () => {
         <ul className="flex justify-center gap-6 py-3">
           {tabs.map((tab) => (
             <li key={tab.href}>
-              <a href={tab.href} className="text-gray-700 font-semibold hover:text-[#4CAF50]">
+              <a href={tab.href} className="text-gray-700 font-semibold hover:text-[#5B84B1]">
                 {tab.label}
               </a>
             </li>

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -92,7 +92,7 @@ const OnboardingWizard = () => {
   const progress = (currentStep / 3) * 100;
 
   return (
-    <section id="onboarding-wizard" className="py-20 bg-gradient-to-br from-[#A8F483] to-[#4CAF50]">
+    <section id="onboarding-wizard" className="py-20 bg-gradient-to-br from-[#BFD8E2] to-[#5B84B1]">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-12">
           <h2 className="text-4xl sm:text-5xl font-black text-white mb-4">
@@ -115,9 +115,9 @@ const OnboardingWizard = () => {
                 <div key={step.id} className="flex flex-col items-center">
                   <div className={`w-16 h-16 rounded-full flex items-center justify-center transition-all duration-300 ${
                     isCompleted 
-                      ? 'bg-[#FFD700] text-gray-800' 
+                      ? 'bg-[#FFCF8B] text-gray-800' 
                       : isActive 
-                        ? 'bg-white text-[#4CAF50]' 
+                        ? 'bg-white text-[#5B84B1]' 
                         : 'bg-white/30 text-white'
                   }`}>
                     {isCompleted ? <Check size={24} /> : <Icon size={24} />}
@@ -134,7 +134,7 @@ const OnboardingWizard = () => {
           {/* Progress bone */}
           <div className="relative h-4 bg-white/20 rounded-full overflow-hidden">
             <div 
-              className="absolute top-0 left-0 h-full bg-[#FFD700] transition-all duration-500 ease-out"
+              className="absolute top-0 left-0 h-full bg-[#FFCF8B] transition-all duration-500 ease-out"
               style={{ width: `${progress}%` }}
             />
             <div className="absolute inset-0 flex items-center justify-center">
@@ -167,7 +167,7 @@ const OnboardingWizard = () => {
                     value={formData.address}
                     onChange={(e) => updateFormData('address', e.target.value)}
                     placeholder="123 Main Street"
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#4CAF50] focus:border-transparent"
+                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#5B84B1] focus:border-transparent"
                   />
                 </div>
                 <div>
@@ -179,12 +179,12 @@ const OnboardingWizard = () => {
                     value={formData.zip}
                     onChange={(e) => updateFormData('zip', e.target.value)}
                     placeholder="12345"
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#4CAF50] focus:border-transparent"
+                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#5B84B1] focus:border-transparent"
                   />
                 </div>
               </div>
               
-              <div className="bg-[#A8F483] rounded-lg p-4 text-center">
+              <div className="bg-[#BFD8E2] rounded-lg p-4 text-center">
                 <p className="text-gray-800 font-bold">
                   ✅ Great news! We service your area
                 </p>
@@ -213,7 +213,7 @@ const OnboardingWizard = () => {
                   >
                     -
                   </button>
-                  <div className="text-4xl font-black text-[#4CAF50]">
+                  <div className="text-4xl font-black text-[#5B84B1]">
                     {formData.dogCount === 5 ? '5+' : formData.dogCount}
                   </div>
                   <button
@@ -236,12 +236,12 @@ const OnboardingWizard = () => {
                     onClick={() => updateFormData('plan', plan.id)}
                     className={`relative cursor-pointer rounded-2xl p-6 border-2 transition-all duration-300 ${
                       formData.plan === plan.id
-                        ? 'border-[#4CAF50] bg-[#A8F483]'
+                        ? 'border-[#5B84B1] bg-[#BFD8E2]'
                         : 'border-gray-200 hover:border-gray-300'
                     }`}
                   >
                     {plan.popular && (
-                      <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 bg-[#FF6B6B] text-white px-3 py-1 rounded-full text-xs font-bold">
+                      <div className="absolute -top-2 left-1/2 transform -translate-x-1/2 bg-[#E27D60] text-white px-3 py-1 rounded-full text-xs font-bold">
                         POPULAR
                       </div>
                     )}
@@ -261,7 +261,7 @@ const OnboardingWizard = () => {
                       <ul className="space-y-1 text-sm text-gray-600">
                         {plan.features.map((feature, index) => (
                           <li key={index} className="flex items-center gap-2">
-                            <Check size={16} className="text-[#4CAF50]" />
+                            <Check size={16} className="text-[#5B84B1]" />
                             {feature}
                           </li>
                         ))}
@@ -293,7 +293,7 @@ const OnboardingWizard = () => {
                   <select
                     value={formData.serviceDay}
                     onChange={(e) => updateFormData('serviceDay', e.target.value)}
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#4CAF50] focus:border-transparent"
+                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#5B84B1] focus:border-transparent"
                   >
                     <option value="">Select a day</option>
                     <option value="monday">Monday</option>
@@ -311,7 +311,7 @@ const OnboardingWizard = () => {
                   <select
                     value={formData.paymentMethod}
                     onChange={(e) => updateFormData('paymentMethod', e.target.value)}
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#4CAF50] focus:border-transparent"
+                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-[#5B84B1] focus:border-transparent"
                   >
                     <option value="">Select payment method</option>
                     <option value="card">Credit/Debit Card</option>
@@ -372,7 +372,7 @@ const OnboardingWizard = () => {
                 (currentStep === 2 && !formData.plan) ||
                 (currentStep === 3 && (!formData.serviceDay || !formData.paymentMethod))
               }
-              className="flex items-center gap-2 px-6 py-3 bg-[#4CAF50] hover:bg-[#45a049] disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-full transition-all duration-300"
+              className="flex items-center gap-2 px-6 py-3 bg-[#5B84B1] hover:bg-[#4A698B] disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-full transition-all duration-300"
             >
               {currentStep === 3 ? 'Complete Order' : 'Next'}
               {currentStep < 3 && <ChevronRight size={20} />}

--- a/src/components/PawCursor.tsx
+++ b/src/components/PawCursor.tsx
@@ -43,7 +43,7 @@ const PawCursor = () => {
       {trails.map((trail, index) => (
         <div
           key={trail.id}
-          className="absolute w-4 h-4 bg-[#4CAF50] rounded-full animate-ping"
+          className="absolute w-4 h-4 bg-[#5B84B1] rounded-full animate-ping"
           style={{
             left: trail.x - 8,
             top: trail.y - 8,

--- a/src/components/ReferralRewards.tsx
+++ b/src/components/ReferralRewards.tsx
@@ -52,7 +52,7 @@ const ReferralRewards = () => {
   };
 
   return (
-    <section id="referral-rewards" className="py-20 bg-gradient-to-br from-[#FFD700] to-[#FFA500]">
+    <section id="referral-rewards" className="py-20 bg-gradient-to-br from-[#FFCF8B] to-[#F6B26B]">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-16">
           <h2 className="text-4xl sm:text-5xl font-black text-white mb-4">
@@ -67,7 +67,7 @@ const ReferralRewards = () => {
           {/* Referral Dashboard */}
           <div className="bg-white rounded-3xl shadow-2xl p-8">
             <div className="text-center mb-8">
-              <div className="w-20 h-20 bg-gradient-to-br from-[#4CAF50] to-[#45a049] rounded-full flex items-center justify-center mx-auto mb-4">
+              <div className="w-20 h-20 bg-gradient-to-br from-[#5B84B1] to-[#4A698B] rounded-full flex items-center justify-center mx-auto mb-4">
                 <Users size={32} className="text-white" />
               </div>
               <h3 className="text-2xl font-bold text-gray-800 mb-2">
@@ -92,7 +92,7 @@ const ReferralRewards = () => {
                 />
                 <button
                   onClick={handleShare}
-                  className="px-6 py-3 bg-[#4CAF50] hover:bg-[#45a049] text-white rounded-lg font-bold transition-all duration-300 flex items-center gap-2"
+                  className="px-6 py-3 bg-[#5B84B1] hover:bg-[#4A698B] text-white rounded-lg font-bold transition-all duration-300 flex items-center gap-2"
                 >
                   <Share2 size={20} />
                   Share
@@ -107,13 +107,13 @@ const ReferralRewards = () => {
 
             {/* Stats */}
             <div className="grid grid-cols-2 gap-4 mb-8">
-              <div className="bg-gradient-to-br from-[#A8F483] to-[#4CAF50] rounded-2xl p-4 text-center">
+              <div className="bg-gradient-to-br from-[#BFD8E2] to-[#5B84B1] rounded-2xl p-4 text-center">
                 <div className="text-2xl font-black text-white mb-1">
                   {referralCount}
                 </div>
                 <p className="text-white/90 text-sm">Friends Referred</p>
               </div>
-              <div className="bg-gradient-to-br from-[#9DE5FF] to-[#00B4FF] rounded-2xl p-4 text-center">
+              <div className="bg-gradient-to-br from-[#D0E5F2] to-[#88B0BF] rounded-2xl p-4 text-center">
                 <div className="text-2xl font-black text-white mb-1">
                   ${referralCount * 25}
                 </div>
@@ -123,7 +123,7 @@ const ReferralRewards = () => {
 
             {/* CTA */}
             <div className="text-center">
-              <button className="w-full py-3 bg-gradient-to-r from-[#FFD700] to-[#FFA500] hover:from-[#FFA500] hover:to-[#FFD700] text-gray-800 font-bold rounded-lg transition-all duration-300 transform hover:scale-105">
+              <button className="w-full py-3 bg-gradient-to-r from-[#FFCF8B] to-[#F6B26B] hover:from-[#F6B26B] hover:to-[#FFCF8B] text-gray-800 font-bold rounded-lg transition-all duration-300 transform hover:scale-105">
                 Invite Friends Now
               </button>
             </div>
@@ -132,7 +132,7 @@ const ReferralRewards = () => {
           {/* Rewards Track */}
           <div className="bg-white rounded-3xl shadow-2xl p-8">
             <div className="text-center mb-8">
-              <div className="w-20 h-20 bg-gradient-to-br from-[#FF6B6B] to-[#FF4444] rounded-full flex items-center justify-center mx-auto mb-4">
+              <div className="w-20 h-20 bg-gradient-to-br from-[#E27D60] to-[#C85A5A] rounded-full flex items-center justify-center mx-auto mb-4">
                 <Trophy size={32} className="text-white" />
               </div>
               <h3 className="text-2xl font-bold text-gray-800 mb-2">
@@ -149,7 +149,7 @@ const ReferralRewards = () => {
                   key={index}
                   className={`relative flex items-center gap-4 p-4 rounded-2xl transition-all duration-300 ${
                     reward.earned
-                      ? 'bg-gradient-to-r from-[#4CAF50] to-[#45a049] text-white'
+                      ? 'bg-gradient-to-r from-[#5B84B1] to-[#4A698B] text-white'
                       : 'bg-gray-50 text-gray-600'
                   }`}
                 >
@@ -176,7 +176,7 @@ const ReferralRewards = () => {
                   </div>
                   
                   {reward.earned && (
-                    <div className="absolute -top-2 -right-2 w-6 h-6 bg-[#FFD700] rounded-full flex items-center justify-center">
+                    <div className="absolute -top-2 -right-2 w-6 h-6 bg-[#FFCF8B] rounded-full flex items-center justify-center">
                       <span className="text-xs">✓</span>
                     </div>
                   )}
@@ -191,7 +191,7 @@ const ReferralRewards = () => {
               </p>
               <div className="bg-gray-200 rounded-full h-2 overflow-hidden">
                 <div 
-                  className="bg-gradient-to-r from-[#4CAF50] to-[#45a049] h-full transition-all duration-500"
+                  className="bg-gradient-to-r from-[#5B84B1] to-[#4A698B] h-full transition-all duration-500"
                   style={{ 
                     width: `${Math.min(100, (referralCount / (rewards.find(r => !r.earned)?.referrals || 10)) * 100)}%` 
                   }}

--- a/src/components/ServiceCards.tsx
+++ b/src/components/ServiceCards.tsx
@@ -16,7 +16,7 @@ const ServiceCards = () => {
         "Reliable service",
         "Eco-friendly disposal"
       ],
-      color: "from-[#9DE5FF] to-[#00B4FF]",
+      color: "from-[#D0E5F2] to-[#88B0BF]",
       icon: Check,
       popular: false
     },
@@ -33,7 +33,7 @@ const ServiceCards = () => {
         "Priority scheduling",
         "Eco-friendly disposal"
       ],
-      color: "from-[#A8F483] to-[#4CAF50]",
+      color: "from-[#BFD8E2] to-[#5B84B1]",
       icon: Star,
       popular: false
     },
@@ -50,7 +50,7 @@ const ServiceCards = () => {
         "Priority scheduling",
         "Eco-friendly disposal"
       ],
-      color: "from-[#FFD700] to-[#FFA500]",
+      color: "from-[#FFCF8B] to-[#F6B26B]",
       icon: Zap,
       popular: false
     },
@@ -68,7 +68,7 @@ const ServiceCards = () => {
         "Priority support",
         "Satisfaction guarantee"
       ],
-      color: "from-[#FF6B6B] to-[#FF4444]",
+      color: "from-[#E27D60] to-[#C85A5A]",
       icon: Crown,
       popular: true,
       glow: true
@@ -101,7 +101,7 @@ const ServiceCards = () => {
                 {/* Popular badge */}
                 {service.popular && (
                   <div className="absolute -top-4 left-1/2 transform -translate-x-1/2">
-                    <div className="bg-[#FF6B6B] text-white px-4 py-2 rounded-full text-sm font-bold shadow-lg">
+                    <div className="bg-[#E27D60] text-white px-4 py-2 rounded-full text-sm font-bold shadow-lg">
                       MOST POPULAR
                     </div>
                   </div>
@@ -136,7 +136,7 @@ const ServiceCards = () => {
                 <div className="space-y-3 mb-8">
                   {service.features.map((feature, featureIndex) => (
                     <div key={featureIndex} className="flex items-center gap-3">
-                      <div className="w-5 h-5 bg-[#4CAF50] rounded-full flex items-center justify-center flex-shrink-0">
+                      <div className="w-5 h-5 bg-[#5B84B1] rounded-full flex items-center justify-center flex-shrink-0">
                         <Check size={12} className="text-white" />
                       </div>
                       <span className="text-sm text-gray-700">{feature}</span>
@@ -147,7 +147,7 @@ const ServiceCards = () => {
                 {/* CTA Button */}
                 <button className={`w-full py-3 px-6 rounded-full font-bold text-sm transition-all duration-300 transform hover:scale-105 ${
                   service.popular
-                    ? 'bg-gradient-to-r from-[#FF6B6B] to-[#FF4444] text-white shadow-lg hover:shadow-xl'
+                    ? 'bg-gradient-to-r from-[#E27D60] to-[#C85A5A] text-white shadow-lg hover:shadow-xl'
                     : 'bg-gray-100 hover:bg-gray-200 text-gray-800'
                 }`}>
                   {service.popular ? 'Choose Deluxe' : 'Select Plan'}
@@ -167,7 +167,7 @@ const ServiceCards = () => {
           <p className="text-lg text-gray-600 mb-6">
             Not sure which plan is right for you?
           </p>
-          <button className="group relative px-8 py-4 bg-[#4CAF50] hover:bg-[#45a049] text-white font-bold text-lg rounded-full transition-all duration-300 transform hover:scale-105 hover:shadow-xl">
+          <button className="group relative px-8 py-4 bg-[#5B84B1] hover:bg-[#4A698B] text-white font-bold text-lg rounded-full transition-all duration-300 transform hover:scale-105 hover:shadow-xl">
             <span className="relative z-10">Get Personalized Recommendation</span>
             <div className="absolute inset-0 bg-white/20 rounded-full scale-0 group-hover:scale-100 transition-transform duration-300" />
           </button>

--- a/src/components/UrgencyRibbon.tsx
+++ b/src/components/UrgencyRibbon.tsx
@@ -42,7 +42,7 @@ const UrgencyRibbon = () => {
   if (!isVisible) return null;
 
   return (
-    <div className="fixed top-0 left-0 right-0 z-50 bg-gradient-to-r from-[#FF6B6B] to-[#FF4444] text-white shadow-lg">
+    <div className="fixed top-0 left-0 right-0 z-50 bg-gradient-to-r from-[#E27D60] to-[#C85A5A] text-white shadow-lg">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between py-3">
           <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- switch from bright greens and yellows to a softer blue-based palette
- update gradients and highlight colors across components

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68783d374cf48323a271f4c4b38c0835