### PR TITLE
feat: add ala carte walk option

### DIFF
--- a/src/components/InteractivePricing.tsx
+++ b/src/components/InteractivePricing.tsx
@@ -1,6 +1,10 @@
 import React, { useState } from 'react';
 
-const InteractivePricing = () => {
+interface InteractivePricingProps {
+  isFirstTime?: boolean;
+}
+
+const InteractivePricing: React.FC<InteractivePricingProps> = ({ isFirstTime = false }) => {
   const [dogCount, setDogCount] = useState(1);
 
   // Pricing structure
@@ -76,7 +80,7 @@ const InteractivePricing = () => {
           </div>
 
           {/* Pricing Comparison */}
-          <div className="grid md:grid-cols-2 gap-8">
+          <div className="grid md:grid-cols-3 gap-8">
             {/* Weekly Basic */}
             <div className="bg-gray-50 rounded-2xl p-6">
               <div className="text-center mb-4">
@@ -144,6 +148,31 @@ const InteractivePricing = () => {
                 <li className="flex items-center gap-2">
                   <span className="text-green-600">✓</span>
                   Free waste bag dispenser
+                </li>
+              </ul>
+            </div>
+            {/* Ala-Carte Walk */}
+            <div className="bg-white rounded-2xl p-6">
+              <div className="text-center mb-4">
+                <h4 className="text-xl font-bold text-gray-800 mb-2">Ala-Carte Walk</h4>
+                <div className="text-3xl font-black text-gray-800">
+                  $25.5
+                  <span className="text-sm font-normal text-gray-600">/hour</span>
+                </div>
+                {isFirstTime && (
+                  <p className="mt-2 text-sm font-bold text-[#E27D60]">
+                    First walk: $10 for 30 min
+                  </p>
+                )}
+              </div>
+              <ul className="space-y-2 text-sm text-gray-600">
+                <li className="flex items-center gap-2">
+                  <span className="text-green-500">✓</span>
+                  Private one-on-one walk
+                </li>
+                <li className="flex items-center gap-2">
+                  <span className="text-green-500">✓</span>
+                  Flexible scheduling
                 </li>
               </ul>
             </div>

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -1,7 +1,11 @@
 import React, { useState } from 'react';
 import { ChevronRight, ChevronLeft, MapPin, Users, Calendar, Check } from 'lucide-react';
 
-const OnboardingWizard = () => {
+interface OnboardingWizardProps {
+  isFirstTime?: boolean;
+}
+
+const OnboardingWizard: React.FC<OnboardingWizardProps> = ({ isFirstTime = false }) => {
   const [currentStep, setCurrentStep] = useState(1);
   const [formData, setFormData] = useState({
     address: '',
@@ -66,6 +70,14 @@ const OnboardingWizard = () => {
       description: 'Unlimited dogs, premium service',
       features: ['Twice-weekly service', 'Unlimited dogs', 'Deep sanitization', 'Free dispenser'],
       popular: true
+    },
+    {
+      id: 'ala-carte-walk',
+      name: 'Ala-Carte Walk',
+      price: 25.5,
+      period: 'hour',
+      description: 'One-hour private walk',
+      features: ['Private walk', 'Flexible scheduling']
     }
   ];
 
@@ -229,7 +241,7 @@ const OnboardingWizard = () => {
               </div>
 
               {/* Plan Selection */}
-              <div className="grid md:grid-cols-2 gap-4">
+              <div className="grid md:grid-cols-3 gap-4">
                 {plans.map((plan) => (
                   <div
                     key={plan.id}
@@ -257,7 +269,13 @@ const OnboardingWizard = () => {
                       <p className="text-sm text-gray-600 mb-4">
                         {plan.description}
                       </p>
-                      
+
+                      {plan.id === 'ala-carte-walk' && isFirstTime && (
+                        <p className="text-sm font-bold text-[#E27D60] mb-4">
+                          First walk: $10 for 30 min
+                        </p>
+                      )}
+
                       <ul className="space-y-1 text-sm text-gray-600">
                         {plan.features.map((feature, index) => (
                           <li key={index} className="flex items-center gap-2">
@@ -343,7 +361,7 @@ const OnboardingWizard = () => {
                         (() => {
                           const plan = plans.find(p => p.id === formData.plan);
                           if (!plan) return '$0';
-                          const multiplier = plan.period === 'week' ? 4 : 2;
+                          const multiplier = plan.period === 'week' ? 4 : 1;
                           return `$${plan.price * multiplier}`;
                         })()
                       }

--- a/src/components/ServiceCards.tsx
+++ b/src/components/ServiceCards.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
-import { Check, Star, Zap, Crown } from 'lucide-react';
+import { Check, Star, Zap, Crown, Footprints } from 'lucide-react';
 
-const ServiceCards = () => {
+interface ServiceCardsProps {
+  isFirstTime?: boolean;
+}
+
+const ServiceCards: React.FC<ServiceCardsProps> = ({ isFirstTime = false }) => {
   const services = [
     {
       name: "Basic Weekly",
@@ -55,6 +59,22 @@ const ServiceCards = () => {
       popular: false
     },
     {
+      name: "Ala-Carte Walk",
+      subtitle: "On-Demand",
+      price: 25.5,
+      period: "hour",
+      description: "One-hour private dog walk",
+      features: [
+        "Flexible scheduling",
+        "Individual attention",
+        "On-leash safety",
+        "Water refresh"
+      ],
+      color: "from-[#C3F0CA] to-[#7BC67B]",
+      icon: Footprints,
+      popular: false
+    },
+    {
       name: "Twice-Weekly Deluxe",
       subtitle: "Add-On",
       price: 8.75,
@@ -87,7 +107,7 @@ const ServiceCards = () => {
           </p>
         </div>
 
-        <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
+        <div className="grid md:grid-cols-2 lg:grid-cols-5 gap-8">
           {services.map((service, index) => {
             const Icon = service.icon;
             
@@ -130,6 +150,11 @@ const ServiceCards = () => {
                   <p className="text-sm text-gray-600">
                     {service.description}
                   </p>
+                  {service.name === 'Ala-Carte Walk' && isFirstTime && (
+                    <p className="mt-2 text-sm font-bold text-[#E27D60]">
+                      First walk: $10 for 30 min
+                    </p>
+                  )}
                 </div>
 
                 {/* Features */}


### PR DESCRIPTION
## Summary
- add Ala-Carte Walk service card with first-time promo banner
- extend pricing and onboarding flows to support walk selection and promo logic

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68940be711508323a4a79c20e3bccff7