### PR TITLE
Add first-week discount messaging and monthly billing details

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import LogoBanner from './components/LogoBanner';
 function App() {
   const [showExitPopup, setShowExitPopup] = useState(false);
   const [showPawCursor, setShowPawCursor] = useState(false);
+  const [isFirstTimeSubscriber, setIsFirstTimeSubscriber] = useState(false);
   const exitPopupTriggeredRef = useRef(false);
 
   useEffect(() => {
@@ -45,6 +46,14 @@ function App() {
     };
   }, []);
 
+  useEffect(() => {
+    const hasSubscribed = localStorage.getItem('hasSubscribed');
+    if (!hasSubscribed) {
+      setIsFirstTimeSubscriber(true);
+      localStorage.setItem('hasSubscribed', 'true');
+    }
+  }, []);
+
   return (
     <div className="min-h-screen bg-[#FFF8F2] relative overflow-x-hidden">
       {showPawCursor && <PawCursor />}
@@ -55,11 +64,11 @@ function App() {
       <About />
       <ComicStrip />
       <HowItWorks />
-      <InteractivePricing />
-      <ServiceCards />
+      <InteractivePricing isFirstTimeSubscriber={isFirstTimeSubscriber} />
+      <ServiceCards isFirstTimeSubscriber={isFirstTimeSubscriber} />
       <DeluxeSpotlight />
       <BeforeAfterGallery />
-      <OnboardingWizard />
+      <OnboardingWizard isFirstTimeSubscriber={isFirstTimeSubscriber} />
       <ReferralRewards />
       <FAQ />
       <Footer />

--- a/src/components/InteractivePricing.tsx
+++ b/src/components/InteractivePricing.tsx
@@ -1,6 +1,12 @@
 import React, { useState } from 'react';
 
-const InteractivePricing = () => {
+interface InteractivePricingProps {
+  isFirstTimeSubscriber?: boolean;
+}
+
+const InteractivePricing: React.FC<InteractivePricingProps> = ({
+  isFirstTimeSubscriber = false,
+}) => {
   const [dogCount, setDogCount] = useState(1);
 
   // Pricing structure
@@ -88,6 +94,12 @@ const InteractivePricing = () => {
                 <p className="text-sm text-gray-600 mt-2">
                   Monthly: ${calculateWeeklyPrice(dogCount) * 4}
                 </p>
+                <p className="text-xs text-gray-500">Billed monthly</p>
+                {isFirstTimeSubscriber && (
+                  <p className="text-xs text-green-600">
+                    First week free when you pay for a month
+                  </p>
+                )}
               </div>
               <ul className="space-y-2 text-sm text-gray-600">
                 <li className="flex items-center gap-2">
@@ -120,7 +132,13 @@ const InteractivePricing = () => {
                 <p className="text-sm text-gray-600 mt-2">
                   Monthly: ${calculateTwiceWeeklyPrice(dogCount) * 4}
                 </p>
-                
+                <p className="text-xs text-gray-500">Billed monthly</p>
+                {isFirstTimeSubscriber && (
+                  <p className="text-xs text-green-600">
+                    First week free when you pay for a month
+                  </p>
+                )}
+
                 {calculateMonthlySavings(dogCount) > 0 && (
                   <div className="mt-2 text-green-600 font-bold">
                     You save ${calculateMonthlySavings(dogCount)}/month!

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -1,7 +1,13 @@
 import React, { useState } from 'react';
 import { ChevronRight, ChevronLeft, MapPin, Users, Calendar, Check } from 'lucide-react';
 
-const OnboardingWizard = () => {
+interface OnboardingWizardProps {
+  isFirstTimeSubscriber?: boolean;
+}
+
+const OnboardingWizard: React.FC<OnboardingWizardProps> = ({
+  isFirstTimeSubscriber = false,
+}) => {
   const [currentStep, setCurrentStep] = useState(1);
   const [formData, setFormData] = useState({
     address: '',
@@ -254,9 +260,15 @@ const OnboardingWizard = () => {
                       ${plan.price}
                       <span className="text-sm font-normal text-gray-600">/{plan.period}</span>
                     </div>
-                      <p className="text-sm text-gray-600 mb-4">
-                        {plan.description}
+                    <p className="text-xs text-gray-500">Billed monthly</p>
+                    {isFirstTimeSubscriber && (
+                      <p className="text-xs text-green-600">
+                        First week free when you pay for a month
                       </p>
+                    )}
+                    <p className="text-sm text-gray-600 mb-4">
+                      {plan.description}
+                    </p>
                       
                       <ul className="space-y-1 text-sm text-gray-600">
                         {plan.features.map((feature, index) => (
@@ -336,19 +348,35 @@ const OnboardingWizard = () => {
                     <span>Plan:</span>
                     <span>{plans.find(p => p.id === formData.plan)?.name}</span>
                   </div>
-                  <div className="flex justify-between font-bold text-gray-800">
-                    <span>Total (monthly):</span>
-                    <span>
-                      {
-                        (() => {
-                          const plan = plans.find(p => p.id === formData.plan);
-                          if (!plan) return '$0';
-                          const multiplier = plan.period === 'week' ? 4 : 2;
-                          return `$${plan.price * multiplier}`;
-                        })()
-                      }
-                    </span>
-                  </div>
+                  {
+                    (() => {
+                      const plan = plans.find(p => p.id === formData.plan);
+                      if (!plan) return null;
+                      const multiplier = plan.period === 'week' ? 4 : 2;
+                      const monthly = plan.price * multiplier;
+                      const credit = isFirstTimeSubscriber ? plan.price : 0;
+                      const total = monthly - credit;
+                      return (
+                        <>
+                          <div className="flex justify-between">
+                            <span>Plan price:</span>
+                            <span>${monthly}</span>
+                          </div>
+                          {isFirstTimeSubscriber && (
+                            <div className="flex justify-between text-green-600">
+                              <span>First week free</span>
+                              <span>- ${plan.price}</span>
+                            </div>
+                          )}
+                          <div className="flex justify-between font-bold text-gray-800">
+                            <span>Total (due today):</span>
+                            <span>${total}</span>
+                          </div>
+                        </>
+                      );
+                    })()
+                  }
+                  <p className="text-xs text-gray-500 mt-2">Billed monthly</p>
                 </div>
               </div>
             </div>

--- a/src/components/ServiceCards.tsx
+++ b/src/components/ServiceCards.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { Check, Star, Zap, Crown } from 'lucide-react';
 
-const ServiceCards = () => {
+interface ServiceCardsProps {
+  isFirstTimeSubscriber?: boolean;
+}
+
+const ServiceCards: React.FC<ServiceCardsProps> = ({
+  isFirstTimeSubscriber = false,
+}) => {
   const services = [
     {
       name: "Basic Weekly",
@@ -126,7 +132,13 @@ const ServiceCards = () => {
                     </span>
                     <span className="text-sm text-gray-600">/{service.period}</span>
                   </div>
-                  
+                  <p className="text-xs text-gray-500">Billed monthly</p>
+                  {isFirstTimeSubscriber && (
+                    <p className="text-xs text-green-600">
+                      First week free when you pay for a month
+                    </p>
+                  )}
+
                   <p className="text-sm text-gray-600">
                     {service.description}
                   </p>


### PR DESCRIPTION
## Summary
- append monthly billing footers and optional first-week promo messages to pricing cards
- support first-time subscriber flag across ServiceCards, InteractivePricing, and OnboardingWizard
- deduct a week's cost in onboarding order summaries when eligible

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68940bf31ae4832393ab5f6e89a3d668