### PR TITLE
feat: highlight intro walk promotions

### DIFF
--- a/src/components/ExitIntentPopup.tsx
+++ b/src/components/ExitIntentPopup.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { X, Gift, Star } from 'lucide-react';
+import { INTRO_WALK_PROMO, FIRST_WEEK_FREE_PROMO } from '../constants/promotions';
 
 interface ExitIntentPopupProps {
   onClose: () => void;
@@ -23,23 +24,19 @@ const ExitIntentPopup: React.FC<ExitIntentPopupProps> = ({ onClose }) => {
             <Gift size={32} className="text-white" />
           </div>
           <h3 className="text-2xl font-black text-white mb-2">
-            Wait! Don't Leave Empty-Handed
+            Wait! Sniff Out These Deals
           </h3>
           <p className="text-white/90">
-            Exclusive offer for Twice-Weekly Deluxe customers only!
+            New walkers get special intro pricing!
           </p>
         </div>
 
         {/* Content */}
         <div className="p-6">
           <div className="text-center mb-6">
-            <div className="text-6xl mb-4">🎁</div>
-            <h4 className="text-xl font-bold text-gray-800 mb-2">
-              FREE Scented Waste-Bag Dispenser
-            </h4>
-            <p className="text-gray-600 text-sm">
-              Worth $25 - Yours free when you sign up for Twice-Weekly Deluxe today!
-            </p>
+            <div className="text-6xl mb-4">🐕‍🦺</div>
+            <h4 className="text-xl font-bold text-gray-800 mb-2">Intro Offers Just for You</h4>
+            <p className="text-gray-600 text-sm">{INTRO_WALK_PROMO} and get your {FIRST_WEEK_FREE_PROMO.toLowerCase()}.</p>
           </div>
 
           {/* Features */}
@@ -48,19 +45,13 @@ const ExitIntentPopup: React.FC<ExitIntentPopupProps> = ({ onClose }) => {
               <div className="w-5 h-5 bg-[#5B84B1] rounded-full flex items-center justify-center">
                 <span className="text-white text-xs">✓</span>
               </div>
-              <span className="text-sm text-gray-700">Premium scented bags included</span>
+              <span className="text-sm text-gray-700">{INTRO_WALK_PROMO}</span>
             </div>
             <div className="flex items-center gap-3">
               <div className="w-5 h-5 bg-[#5B84B1] rounded-full flex items-center justify-center">
                 <span className="text-white text-xs">✓</span>
               </div>
-              <span className="text-sm text-gray-700">Weather-resistant mounting</span>
-            </div>
-            <div className="flex items-center gap-3">
-              <div className="w-5 h-5 bg-[#5B84B1] rounded-full flex items-center justify-center">
-                <span className="text-white text-xs">✓</span>
-              </div>
-              <span className="text-sm text-gray-700">Unlimited dogs covered</span>
+              <span className="text-sm text-gray-700">{FIRST_WEEK_FREE_PROMO}</span>
             </div>
           </div>
 
@@ -68,20 +59,16 @@ const ExitIntentPopup: React.FC<ExitIntentPopupProps> = ({ onClose }) => {
           <div className="bg-[#FFCF8B] rounded-lg p-4 mb-6">
             <div className="flex items-center gap-2 justify-center">
               <Star size={16} className="text-gray-800" />
-              <span className="text-sm font-bold text-gray-800">
-                Limited time offer - Only for new Deluxe subscribers!
-              </span>
+              <span className="text-sm font-bold text-gray-800">Lock in these intro deals today!</span>
             </div>
           </div>
 
           {/* CTA */}
           <button className="w-full py-3 bg-gradient-to-r from-[#5B84B1] to-[#4A698B] hover:from-[#4A698B] hover:to-[#5B84B1] text-white font-bold rounded-full transition-all duration-300 transform hover:scale-105">
-            Claim My Free Dispenser + Start Deluxe
+            Claim My Intro Offer
           </button>
-          
-          <p className="text-xs text-gray-500 text-center mt-3">
-            No commitment. Cancel anytime. Offer expires in 24 hours.
-          </p>
+
+          <p className="text-xs text-gray-500 text-center mt-3">No commitment. Cancel anytime.</p>
         </div>
       </div>
     </div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { ChevronDown, Play } from 'lucide-react';
+import { INTRO_WALK_PROMO, FIRST_WEEK_FREE_PROMO } from '../constants/promotions';
 
 const Hero = () => {
   const [scrollY, setScrollY] = useState(0);
@@ -50,13 +51,24 @@ const Hero = () => {
                 <span className="relative z-10">Start My Plan</span>
                 <div className="absolute inset-0 bg-white/20 rounded-full scale-0 group-hover:scale-100 transition-transform duration-300"></div>
               </button>
-              <button 
+              <button
                 onClick={scrollToStory}
                 className="group flex items-center gap-2 px-8 py-4 bg-white/20 hover:bg-white/30 text-white font-bold text-lg rounded-full transition-all duration-300 backdrop-blur-sm"
               >
                 <Play size={20} />
                 See the Story
               </button>
+            </div>
+
+            <div className="grid sm:grid-cols-2 gap-4 mt-6 text-sm sm:text-base">
+              <div className="flex items-center gap-2 bg-white/10 px-4 py-3 rounded-xl backdrop-blur-sm text-white">
+                <span className="text-xl">🐾</span>
+                <span>{INTRO_WALK_PROMO}</span>
+              </div>
+              <div className="flex items-center gap-2 bg-[#FFCF8B] px-4 py-3 rounded-xl text-gray-800 font-semibold">
+                <span className="text-xl">🎉</span>
+                <span>{FIRST_WEEK_FREE_PROMO}</span>
+              </div>
             </div>
           </div>
 

--- a/src/components/UrgencyRibbon.tsx
+++ b/src/components/UrgencyRibbon.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Clock, X } from 'lucide-react';
+import { COMBINED_PROMO } from '../constants/promotions';
 
 const UrgencyRibbon = () => {
   const [isVisible, setIsVisible] = useState(true);
@@ -45,15 +46,15 @@ const UrgencyRibbon = () => {
     <div className="fixed top-0 left-0 right-0 z-50 bg-gradient-to-r from-[#E27D60] to-[#C85A5A] text-white shadow-lg">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between py-3">
-          <div className="flex items-center gap-3">
-            <div className="w-8 h-8 bg-white/20 rounded-full flex items-center justify-center">
-              <Clock size={16} className="animate-pulse" />
+            <div className="flex items-center gap-3">
+              <div className="w-8 h-8 bg-white/20 rounded-full flex items-center justify-center">
+                <Clock size={16} className="animate-pulse" />
+              </div>
+              <div className="flex items-center gap-2 text-sm sm:text-base">
+                <span className="font-bold">Limited Time:</span>
+                <span>{COMBINED_PROMO}</span>
+              </div>
             </div>
-            <div className="flex items-center gap-2 text-sm sm:text-base">
-              <span className="font-bold">Limited Time:</span>
-              <span>Book by Tuesday 8 PM for Wednesday service pickup!</span>
-            </div>
-          </div>
           
           <div className="flex items-center gap-4">
             {/* Countdown */}

--- a/src/constants/promotions.ts
+++ b/src/constants/promotions.ts
@@ -1,0 +1,3 @@
+export const INTRO_WALK_PROMO = 'Try your first 30-min walk for $10';
+export const FIRST_WEEK_FREE_PROMO = 'First week free with monthly plans';
+export const COMBINED_PROMO = `${INTRO_WALK_PROMO} — ${FIRST_WEEK_FREE_PROMO}!`;


### PR DESCRIPTION
## Summary
- centralize promo copy in `src/constants/promotions.ts`
- ensure hero, urgency ribbon, and exit intent popup pull from shared constants for consistent messaging

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68940bfc1cd4832398884e76fb9e8656